### PR TITLE
docs: record v1 release candidate verification

### DIFF
--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -3,11 +3,12 @@
 - Release date: pending
 - Git tag: `v1.0.0` (planned; not created)
 - Evidence status: release-candidate corrections are implemented on the
-  archived `v1-public-release-readiness` OpenSpec change, two final reviews returned
-  GO, and the deterministic and pull-request gates pass. Do not tag until the gated
-  squash merge and pre-tag repository items below are complete. Tagged-image
-  verification occurs after the tag and blocks the public release announcement
-  rather than tag creation.
+  archived `v1-public-release-readiness` OpenSpec change and were squash-merged to
+  `main` as `d808d8dd2258081cc206d5a681c18cd3297cc0ba`. Two final reviews returned
+  GO, and the deterministic, pull-request, and pre-tag candidate-image gates pass.
+  The annotated `v1.0.0` tag is the next release action. Tagged-image verification
+  occurs after the tag and blocks the public release announcement rather than tag
+  creation.
 
 ## Deterministic checks
 
@@ -119,8 +120,18 @@ the complete gate scope, distinguishing process environment from Compose
   public `main` ruleset requires those checks plus a pull request, linear history,
   conversation resolution, and squash-only merging, with force pushes and deletion
   blocked and no bypass actors.
-- The gated squash merge, merged-main `sha-<full-commit>` manifest, public GHCR
-  package, and anonymous clean install: pending.
+- Pull request 1 was squash-merged to `main` as
+  `d808d8dd2258081cc206d5a681c18cd3297cc0ba`. The post-merge
+  `just release-check` passed with 445 backend tests, 64 frontend tests, the Chromium
+  journey, and production container smoke.
+- The public `sha-d808d8dd2258081cc206d5a681c18cd3297cc0ba` GHCR candidate has OCI
+  digest `sha256:4e8bf86c680d58b439df79610b73b4ea48c967ad0e84f941fc5cf0c7a490c9fc`
+  and contains `linux/amd64` and `linux/arm64` manifests. Its OCI source label links
+  to the public repository.
+- A credential-free manifest inspection and pull succeeded. A disposable clean
+  Compose installation passed health and SPA checks, ran as non-root UID 999, and
+  preserved its SQLite marker across container recreation. Its container, network,
+  named volume, configuration file, and empty directory were removed afterward.
 - The `1.0.0`, `1.0`, `1`, `latest`, and immutable SHA tags, amd64/arm64 manifest,
   tagged clean install, and GitHub Release: pending post-tag verification.
 


### PR DESCRIPTION
## What / why

Record the completed v1.0.0 pre-tag verification after the release-readiness merge.
Capture the protected merge commit, post-merge release gate, public multi-architecture
candidate digest, and credential-free clean-install and persistence results.

## Spec

- OpenSpec change: `n/a: documentation-only release evidence`
- [x] No archive required

## Checklist

- [x] `just check` passes locally
- [x] Title is the Conventional Commit subject for the squash