### PR TITLE
fix: keep GHCR SHA tags immutable

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -60,7 +60,7 @@ jobs:
           flavor: latest=false
           tags: |
             type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
-            type=sha,format=long,prefix=sha-
+            type=sha,format=long,prefix=sha-,enable=${{ github.ref == 'refs/heads/main' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -83,7 +83,9 @@ def test_readme_links_every_living_operator_document() -> None:
     assert "OWNER/REPOSITORY" not in readme + releasing + evidence
     assert "empty **public** `ZacharyArthur/tasterr` repository" in releasing
     assert "`check`, `e2e`, and `container-smoke`" in releasing
-    assert "sha-<full-commit>" in releasing
+    assert "leave the existing `sha-<full-commit>` candidate unchanged" in releasing
+    assert "pin the `1.0.0` digest" in releasing
+    assert "do not move, delete, or reuse the published tag" in releasing
     assert "Public repositories support this ruleset on GitHub Free" in releasing
     assert "private vulnerability reporting" in releasing
     assert "do not use a create-and-push shortcut" in releasing

--- a/backend/tests/test_release_version.py
+++ b/backend/tests/test_release_version.py
@@ -33,7 +33,6 @@ def test_image_workflow_maps_v1_tag_to_release_aliases() -> None:
     image = (ROOT / ".github" / "workflows" / "image.yml").read_text(encoding="utf-8")
 
     assert 'tags:\n      - "v*"' in image
-    assert "type=sha,format=long,prefix=sha-" in image
     assert "type=semver,pattern={{version}}" in image
     assert "type=semver,pattern={{major}}.{{minor}}" in image
     assert "type=semver,pattern={{major}}" in image

--- a/backend/tests/test_workflows.py
+++ b/backend/tests/test_workflows.py
@@ -69,7 +69,10 @@ def test_image_workflow_publishes_only_after_native_smoke() -> None:
     assert "packages: write" in image
     assert "platforms: linux/amd64,linux/arm64" in image
     assert "type=raw,value=main" in image
-    assert "type=sha,format=long,prefix=sha-" in image
+    sha_rules = [line.strip() for line in image.splitlines() if line.strip().startswith("type=sha")]
+    assert sha_rules == [
+        "type=sha,format=long,prefix=sha-,enable=${{ github.ref == 'refs/heads/main' }}"
+    ]
     assert "type=semver,pattern={{version}}" in image
     assert "type=semver,pattern={{major}}.{{minor}}" in image
     assert "type=semver,pattern={{major}}" in image

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -146,15 +146,15 @@ npx @devcontainers/cli exec --workspace-folder . git pull --ff-only
 npx @devcontainers/cli exec --workspace-folder . just release-check
 ```
 
-The image workflow on the merged `main` commit publishes public `main` and immutable
-`sha-<full-commit>` candidate tags. Before tagging:
+The image workflow on the merged `main` commit publishes public `main` and
+commit-addressed `sha-<full-commit>` candidate tags. Before tagging:
 
 1. Inspect the candidate manifest and confirm both `linux/amd64` and `linux/arm64`.
 2. Confirm that the GHCR package is linked to the public repository and explicitly
    public; repository and package visibility are separate controls.
 3. From an environment with no GHCR credentials, verify an anonymous pull. Then use
    a disposable empty directory, new Compose project, and `.env` to install the
-   immutable
+   commit-SHA
    `ghcr.io/zacharyarthur/tasterr:sha-<full-commit>` candidate. Verify health, SPA
    serving, non-root uid, and named-volume persistence across recreation.
 4. Remove the disposable project, volume, network, and secret file. Record the
@@ -169,8 +169,9 @@ npx @devcontainers/cli exec --workspace-folder . git tag -a v1.0.0 -m "v1.0.0"
 npx @devcontainers/cli exec --workspace-folder . git push origin v1.0.0
 ```
 
-Wait for the image workflow. It must publish `1.0.0`, `1.0`, `1`, `latest`, and the
-immutable `sha-<full-commit>` tag. Inspect the manifest and confirm both platforms:
+Wait for the image workflow. It must publish `1.0.0`, `1.0`, `1`, and `latest`, and
+leave the existing `sha-<full-commit>` candidate unchanged. Inspect the stable
+manifest and confirm both platforms:
 
 ```console
 npx @devcontainers/cli exec --workspace-folder . docker buildx imagetools inspect ghcr.io/zacharyarthur/tasterr:1.0.0
@@ -183,10 +184,15 @@ Perform a fresh install in an empty directory with a new external network, dispo
 named-volume persistence. Delete every disposable resource after verification.
 
 Publish release notes only after the manifest and fresh install pass. Summarize user-
-visible changes, upgrade steps, known limitations, and the immutable image digest;
-do not reproduce private release evidence. Publish the GitHub Release only after
-`1.0.0`, `1.0`, `1`, `latest`, and `sha-<full-commit>` all resolve to the expected
-release commit and the tagged clean-install smoke passes.
+visible changes, upgrade steps, and known limitations; pin the `1.0.0` digest as the
+released artifact and do not reproduce private release evidence. Publish the GitHub
+Release only after `1.0.0`, `1.0`, `1`, and `latest` resolve to the expected release
+commit, the `sha-<full-commit>` candidate still resolves to its recorded pre-tag
+digest, and the tagged clean-install smoke passes.
+
+If any post-tag check fails, do not move, delete, or reuse the published tag.
+Document the failure, fix forward through the normal protected-`main` workflow, and
+issue the next patch version.
 
 The selected public coordinate is `ZacharyArthur/tasterr` and the container path is
 `ghcr.io/zacharyarthur/tasterr`; verify both before repository creation. Repository

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -1,14 +1,14 @@
 # Tasterr v1.0.0 release evidence
 
-- Release date: pending
-- Git tag: `v1.0.0` (planned; not created)
+- Release date: pending GitHub Release disposition
+- Git tag: `v1.0.0`
 - Evidence status: release-candidate corrections are implemented on the
   archived `v1-public-release-readiness` OpenSpec change and were squash-merged to
   `main` as `d808d8dd2258081cc206d5a681c18cd3297cc0ba`. Two final reviews returned
   GO, and the deterministic, pull-request, and pre-tag candidate-image gates pass.
-  The annotated `v1.0.0` tag is the next release action. Tagged-image verification
-  occurs after the tag and blocks the public release announcement rather than tag
-  creation.
+  The release was approved for its annotated `v1.0.0` tag. The public tag and images
+  exist, but the GitHub Release remains withheld after post-tag verification found
+  the SHA-alias integrity issue recorded below.
 
 ## Deterministic checks
 
@@ -132,8 +132,29 @@ the complete gate scope, distinguishing process environment from Compose
   Compose installation passed health and SPA checks, ran as non-root UID 999, and
   preserved its SQLite marker across container recreation. Its container, network,
   named volume, configuration file, and empty directory were removed afterward.
-- The `1.0.0`, `1.0`, `1`, `latest`, and immutable SHA tags, amd64/arm64 manifest,
-  tagged clean install, and GitHub Release: pending post-tag verification.
+- Release-evidence pull request 3 was squash-merged as
+  `b777590dd07a404e67d00512ae8860d8671d17a5`. Its public `main` candidate,
+  `sha-b777590dd07a404e67d00512ae8860d8671d17a5`, initially resolved to
+  `sha256:9ba128bdac3b2568aff7bb3180c57e3eba9868b7c1f68fa470b60f0f00c2a6ce`;
+  before the tag was pushed, both target architectures and a credential-free clean
+  installation passed.
+- Pre-announcement verification of the public `v1.0.0` tag found that its
+  workflow republished that SHA alias with tag-specific metadata at
+  `sha256:29da7914dbc804b012b54c785c807ed85096d778fad888474af26bfca910976a`.
+  The `1.0.0`, `1.0`, `1`, `latest`, and
+  `sha-b777590dd07a404e67d00512ae8860d8671d17a5` aliases all resolve to that digest
+  and contain `linux/amd64` and `linux/arm64` manifests.
+- An anonymous pull and disposable clean installation of `1.0.0` passed health and
+  SPA checks, ran as non-root UID 999, and preserved its SQLite marker across
+  recreation. Every disposable resource and configuration file was removed.
+- No GitHub Release was published. The existing `v1.0.0` tag remains at
+  `b777590dd07a404e67d00512ae8860d8671d17a5`; the immutable-tag policy forbids
+  moving or deleting it. The correction fixes forward on `main` for the next patch
+  version.
+- The post-tag workflow correction publishes commit-SHA aliases only from `main`;
+  SemVer tag events cannot rewrite an existing candidate alias in subsequent
+  releases. A structural regression assertion rejects any additional or unguarded
+  SHA metadata rule. The tagged `v1.0.0` tree remains pre-fix.
 
 ## Known limitations
 


### PR DESCRIPTION
## What / why

Prevent SemVer workflow runs from republishing an existing commit-SHA image alias
with tag-specific metadata. Publish SHA aliases only from `main`, strengthen the
regression contract, and correct the release procedure and v1.0.0 evidence to record
the actual public state and immutable-tag fix-forward policy.

## Spec

- OpenSpec change: `n/a: bug fix restoring container image immutability`
- [x] No archive required

## Checklist

- [x] `just check` passes locally
- [x] Title is the Conventional Commit subject for the squash