### PR TITLE
chore: prepare v1.0.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ values listed above. Pin the desired version from the
 ```yaml
 services:
   tasterr:
-    image: ghcr.io/zacharyarthur/tasterr:1.0.0
+    image: ghcr.io/zacharyarthur/tasterr:1.0.1
     restart: unless-stopped
     ports:
       - "127.0.0.1:8000:8000"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tasterr"
-version = "1.0.0"
+version = "1.0.1"
 description = "Self-hosted, Netflix-style discovery front-end for a household media stack"
 license = "AGPL-3.0-only"
 requires-python = ">=3.13"

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -54,7 +54,7 @@ def test_readme_links_every_living_operator_document() -> None:
     assert "A shared Docker network is not required" in readme
     assert "TASTERR_HTTP_PORT=8000" in readme
     assert "github.com/ZacharyArthur/tasterr/actions/workflows/gate.yml/badge.svg" in readme
-    assert "image: ghcr.io/zacharyarthur/tasterr:1.0.0" in readme
+    assert "image: ghcr.io/zacharyarthur/tasterr:1.0.1" in readme
     assert '- "127.0.0.1:8000:8000"' in readme
     assert "tasterr-data:/data" in readme
     assert "does not require a\n`.env` file" in readme
@@ -79,12 +79,12 @@ def test_readme_links_every_living_operator_document() -> None:
     assert "This is a Compose concern, not an application requirement" in configuration
 
     releasing = _read(DOCS / "RELEASING.md")
-    evidence = _read(DOCS / "releases" / "v1.0.0.md")
+    evidence = _read(DOCS / "releases" / "v1.0.1.md")
     assert "OWNER/REPOSITORY" not in readme + releasing + evidence
     assert "empty **public** `ZacharyArthur/tasterr` repository" in releasing
     assert "`check`, `e2e`, and `container-smoke`" in releasing
     assert "leave the existing `sha-<full-commit>` candidate unchanged" in releasing
-    assert "pin the `1.0.0` digest" in releasing
+    assert "pin the `1.0.1` digest" in releasing
     assert "do not move, delete, or reuse the published tag" in releasing
     assert "Public repositories support this ruleset on GitHub Free" in releasing
     assert "private vulnerability reporting" in releasing
@@ -131,8 +131,8 @@ def test_release_check_is_deterministic_and_keeps_external_checks_explicit() -> 
     assert "just release-check" in releasing
     assert "just audit" in releasing
     assert "just test-live" in releasing
-    assert "v1.0.0" in releasing
-    assert "archive v1-public-release-readiness" in releasing
+    assert "v1.0.1" in releasing
+    assert "archive <change-id>" in releasing
 
 
 def test_public_security_policy_is_private_and_actionable() -> None:

--- a/backend/tests/test_release_version.py
+++ b/backend/tests/test_release_version.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from pydantic import BaseModel
 
 ROOT = Path(__file__).resolve().parents[2]
-VERSION = "1.0.0"
+VERSION = "1.0.1"
 
 
 class PackageManifest(BaseModel):
@@ -39,10 +39,10 @@ def test_image_workflow_maps_v1_tag_to_release_aliases() -> None:
     assert "type=raw,value=latest" in image
 
 
-def test_release_documents_name_the_first_stable_tag() -> None:
+def test_release_documents_name_the_current_stable_tag() -> None:
     releasing = (ROOT / "docs" / "RELEASING.md").read_text(encoding="utf-8")
-    evidence = (ROOT / "docs" / "releases" / "v1.0.0.md").read_text(encoding="utf-8")
+    evidence = (ROOT / "docs" / "releases" / "v1.0.1.md").read_text(encoding="utf-8")
 
-    assert "package version is\n`1.0.0`" in releasing
-    assert "Git tag is `v1.0.0`" in releasing
-    assert "Git tag: `v1.0.0`" in evidence
+    assert f"package version is\n`{VERSION}`" in releasing
+    assert f"Git tag is `v{VERSION}`" in releasing
+    assert f"Git tag: `v{VERSION}`" in evidence

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "tasterr"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,8 +1,10 @@
 # Releasing
 
-This procedure is for stable v1 releases. The first stable package version is
-`1.0.0`, its Git tag is `v1.0.0`, and its image is published by the `image` workflow
-only after the OpenSpec change and code are archived and squash-merged together.
+This procedure is for stable v1 releases. The current package version is
+`1.0.1`, its Git tag is `v1.0.1`, and its image is published by the `image` workflow
+only after all release changes are squash-merged to protected `main`. The published
+`v1.0.0` tag is retained for provenance, but no GitHub Release was announced for it;
+`v1.0.1` is the immutable-tag fix-forward and first announced release.
 
 ## 1. Prepare the required devcontainer
 
@@ -41,7 +43,7 @@ native image/Compose smoke sequentially. Any failure blocks the release.
 npx @devcontainers/cli exec --workspace-folder . just release-check
 ```
 
-Record the date and result in `docs/releases/v1.0.0.md`. This command intentionally
+Record the date and result in `docs/releases/v1.0.1.md`. This command intentionally
 does not imply that audits, security review, or live contracts passed.
 
 ## 4. Audit locked dependencies
@@ -84,23 +86,25 @@ release evidence records the baseline date/version/scope plus the waiver rationa
 without claiming a fresh pass. Any change to those surfaces invalidates the waiver.
 Remove the temporary secret file after a run.
 
-## 6. Validate and archive the OpenSpec change
+## 6. Validate and archive any OpenSpec change
 
-Run strict validation on the change branch:
+When the release contains an OpenSpec change, run strict validation on its change
+branch:
 
 ```console
-npx @devcontainers/cli exec --workspace-folder . npx --yes @fission-ai/openspec@1.5.0 validate v1-public-release-readiness --strict --no-interactive
+npx @devcontainers/cli exec --workspace-folder . npx --yes @fission-ai/openspec@1.5.0 validate <change-id> --strict --no-interactive
 ```
 
-After every task and release-evidence field is complete, archive before merging so
-the implementation and living specs land atomically:
+After every task is complete, archive before merging so the implementation and
+living specs land atomically:
 
 ```console
-npx @devcontainers/cli exec --workspace-folder . npx --yes @fission-ai/openspec@1.5.0 archive v1-public-release-readiness
+npx @devcontainers/cli exec --workspace-folder . npx --yes @fission-ai/openspec@1.5.0 archive <change-id>
 ```
 
 Review the archive diff and rerun `just check`. Do not use `--skip-specs` or
-`--no-validate` for this change.
+`--no-validate`. A release containing only bug fixes, documentation, chores, or
+dependency bumps may record OpenSpec as `n/a` and skip this section.
 
 ## 7. Bootstrap GitHub, open the PR, and squash merge
 
@@ -165,28 +169,28 @@ commit-addressed `sha-<full-commit>` candidate tags. Before tagging:
 After every pre-tag release-record field is final, create and push the annotated tag:
 
 ```console
-npx @devcontainers/cli exec --workspace-folder . git tag -a v1.0.0 -m "v1.0.0"
-npx @devcontainers/cli exec --workspace-folder . git push origin v1.0.0
+npx @devcontainers/cli exec --workspace-folder . git tag -a v1.0.1 -m "v1.0.1"
+npx @devcontainers/cli exec --workspace-folder . git push origin v1.0.1
 ```
 
-Wait for the image workflow. It must publish `1.0.0`, `1.0`, `1`, and `latest`, and
+Wait for the image workflow. It must publish `1.0.1`, `1.0`, `1`, and `latest`, and
 leave the existing `sha-<full-commit>` candidate unchanged. Inspect the stable
 manifest and confirm both platforms:
 
 ```console
-npx @devcontainers/cli exec --workspace-folder . docker buildx imagetools inspect ghcr.io/zacharyarthur/tasterr:1.0.0
+npx @devcontainers/cli exec --workspace-folder . docker buildx imagetools inspect ghcr.io/zacharyarthur/tasterr:1.0.1
 ```
 
 Perform a fresh install in an empty directory with a new external network, disposable
 `.env`, and new Compose project. Set
-`TASTERR_IMAGE=ghcr.io/zacharyarthur/tasterr:1.0.0`, run `docker compose pull` and
+`TASTERR_IMAGE=ghcr.io/zacharyarthur/tasterr:1.0.1`, run `docker compose pull` and
 `docker compose up -d --no-build`, then verify health, SPA serving, non-root uid, and
 named-volume persistence. Delete every disposable resource after verification.
 
 Publish release notes only after the manifest and fresh install pass. Summarize user-
-visible changes, upgrade steps, and known limitations; pin the `1.0.0` digest as the
+visible changes, upgrade steps, and known limitations; pin the `1.0.1` digest as the
 released artifact and do not reproduce private release evidence. Publish the GitHub
-Release only after `1.0.0`, `1.0`, `1`, and `latest` resolve to the expected release
+Release only after `1.0.1`, `1.0`, `1`, and `latest` resolve to the expected release
 commit, the `sha-<full-commit>` candidate still resolves to its recorded pre-tag
 digest, and the tagged clean-install smoke passes.
 

--- a/docs/releases/v1.0.0.md
+++ b/docs/releases/v1.0.0.md
@@ -1,6 +1,6 @@
 # Tasterr v1.0.0 release evidence
 
-- Release date: pending GitHub Release disposition
+- Release date: not published; superseded by the `v1.0.1` fix-forward
 - Git tag: `v1.0.0`
 - Evidence status: release-candidate corrections are implemented on the
   archived `v1-public-release-readiness` OpenSpec change and were squash-merged to

--- a/docs/releases/v1.0.1.md
+++ b/docs/releases/v1.0.1.md
@@ -1,0 +1,77 @@
+# Tasterr v1.0.1 release evidence
+
+- Release date: pending GitHub Release
+- Git tag: `v1.0.1`
+- Evidence status: release preparation. This patch is the fix-forward for the
+  `v1.0.0` SHA-alias publication defect and will be Tasterr's first announced
+  GitHub Release.
+
+## Scope
+
+- Pull request 4 was squash-merged to `main` as
+  `c27a6e02b1d96420b905ec3a9bfa6c5b8da43b51`. SHA image aliases are now emitted
+  only for `main`; SemVer tag workflows cannot rewrite a commit-addressed alias.
+- The patch release changes package metadata, release documentation, and the
+  published image coordinate. It does not change application runtime behavior,
+  authentication, Seerr/TMDB clients, request contracts, database schema, or
+  configuration.
+- The public `v1.0.0` tag remains at
+  `b777590dd07a404e67d00512ae8860d8671d17a5` and will not be moved, deleted, or
+  reused.
+
+## Completed verification
+
+- All required pull-request jobs for pull request 4 passed: `check`, `e2e`, and
+  `container-smoke`.
+- Post-merge `just release-check` passed on 2026-07-26 with 445 backend tests,
+  64 frontend tests, current generated API types, the production frontend build,
+  the Chromium login/home/detail/request journey, and production container health,
+  private logs, hardened headers, SPA serving, non-root runtime, and volume
+  persistence.
+- The public `sha-c27a6e02b1d96420b905ec3a9bfa6c5b8da43b51` intermediate candidate
+  has OCI digest
+  `sha256:1687f53ce4578f783f4b45e2d5b9b7a88f1a3d165310c2498fca09042de4f3ea`
+  and contains `linux/amd64` and `linux/arm64` manifests.
+- Anonymous inspection confirmed that `1.0.0` and
+  `sha-b777590dd07a404e67d00512ae8860d8671d17a5` remain unchanged at
+  `sha256:29da7914dbc804b012b54c785c807ed85096d778fad888474af26bfca910976a`.
+
+## Dependency audit
+
+- `pip-audit` reported no known vulnerabilities on 2026-07-26. The local Tasterr
+  package was skipped because it is not a PyPI distribution.
+- `npm audit --omit=dev` reported no known vulnerabilities.
+- Full `npm audit` continues to report four high-severity package instances under
+  the accepted development-only
+  [`GHSA-mh99-v99m-4gvg`](https://github.com/advisories/GHSA-mh99-v99m-4gvg)
+  Redocly/minimatch/brace-expansion path. It processes only the repository's trusted
+  generated OpenAPI schema and is absent from the production installation and image.
+  The suggested forced downgrade of `openapi-typescript` is breaking and is not
+  applicable; upgrade when the compatible upstream dependency tree is patched.
+
+## Pre-tag requirements
+
+- Squash-merge the version and release-documentation update through protected
+  `main`.
+- Rerun `just release-check`, inspect the resulting commit-SHA candidate, and
+  perform its credential-free clean-install and persistence smoke.
+- Create and push the annotated `v1.0.1` tag only after the candidate passes.
+- Confirm `1.0.1`, `1.0`, `1`, and `latest` resolve to the tagged release while
+  the commit-SHA candidate retains its pre-tag digest.
+- Perform a credential-free clean installation of `1.0.1` before publishing the
+  GitHub Release.
+
+## Live-contract disposition
+
+The release owner waived another live Seerr run. The complete Seerr 3.3.0 baseline
+from 2026-07-13 passed ten cases with no skips, and this patch does not change Seerr
+clients, authentication/session behavior, request/availability contracts, or the
+live harness.
+
+## Known limitations
+
+- Tasterr v1.0 is a single-process household service; multiple workers are not
+  supported.
+- It does not bundle Seerr, play media, import Plex history, or provide native apps.
+- A non-failing upstream TestClient deprecation remains scheduled for dependency
+  maintenance.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "frontend",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "1.0.0",
+			"version": "1.0.1",
 			"dependencies": {
 				"@tailwindcss/vite": "^4.3.2",
 				"@tanstack/react-query": "^5.101.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",


### PR DESCRIPTION
## What / why

Bump backend and frontend package metadata and published-image documentation to
v1.0.1 so the source, Git tag, and GHCR release agree. Update the release runbook
and evidence to retain v1.0.0 for provenance while preparing the immutable-tag
fix-forward as Tasterr's first announced GitHub Release.

## Spec

- OpenSpec change: `n/a: release metadata and documentation`
- [x] No archive required

## Checklist

- [x] `just check` passes locally
- [x] Production dependency audits are clean
- [x] Accepted development-only audit finding is documented
- [x] Title is the Conventional Commit subject for the squash