### PR TITLE
chore: finalize v1.0.1 release process

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -6,6 +6,9 @@ on:
       - main
     tags:
       - "v*"
+    paths-ignore:
+      - "docs/**"
+      - README.md
 
 permissions:
   contents: read

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -85,6 +85,8 @@ def test_readme_links_every_living_operator_document() -> None:
     assert "`check`, `e2e`, and `container-smoke`" in releasing
     assert "leave the existing `sha-<full-commit>` candidate unchanged" in releasing
     assert "pin the `1.0.1` digest" in releasing
+    assert "GitHub Release is the authoritative post-tag record" in releasing
+    assert "do not create a post-release evidence commit" in releasing
     assert "do not move, delete, or reuse the published tag" in releasing
     assert "Public repositories support this ruleset on GitHub Free" in releasing
     assert "private vulnerability reporting" in releasing

--- a/backend/tests/test_release_version.py
+++ b/backend/tests/test_release_version.py
@@ -46,3 +46,5 @@ def test_release_documents_name_the_current_stable_tag() -> None:
     assert f"package version is\n`{VERSION}`" in releasing
     assert f"Git tag is `v{VERSION}`" in releasing
     assert f"Git tag: `v{VERSION}`" in evidence
+    assert re.search(r"(?m)^- Release date: \d{4}-\d{2}-\d{2}$", evidence)
+    assert "pending GitHub Release" not in evidence

--- a/backend/tests/test_workflows.py
+++ b/backend/tests/test_workflows.py
@@ -44,6 +44,8 @@ def test_pull_request_gate_runs_all_blocking_local_contracts() -> None:
 
     assert "pull_request:" in gate
     assert "\n  push:" not in gate
+    assert "paths:" not in gate
+    assert "paths-ignore:" not in gate
     assert "permissions:\n  contents: read" in gate
     assert "  check:" in gate
     assert "  e2e:" in gate
@@ -56,10 +58,13 @@ def test_pull_request_gate_runs_all_blocking_local_contracts() -> None:
 
 def test_image_workflow_publishes_only_after_native_smoke() -> None:
     image = _text("image.yml")
+    image_config = yaml.safe_load(image)
+    push_config = image_config[True]["push"]
 
     assert "pull_request:" not in image
     assert "branches:\n      - main" in image
     assert 'tags:\n      - "v*"' in image
+    assert push_config["paths-ignore"] == ["docs/**", "README.md"]
     assert "permissions:\n  contents: read" in image
     assert "needs: smoke" in image
     assert image.index("just container-smoke") < image.index("docker/login-action")

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -46,6 +46,12 @@ npx @devcontainers/cli exec --workspace-folder . just release-check
 Record the date and result in `docs/releases/v1.0.1.md`. This command intentionally
 does not imply that audits, security review, or live contracts passed.
 
+For subsequent releases, the committed evidence file is the pre-tag record. Write
+it so it remains true after publication: use an `approved for release` disposition,
+not a pending post-tag state, and do not predict a manifest digest or publication
+time. The GitHub Release is the authoritative post-tag record for the final digest
+and post-tag smoke results.
+
 ## 4. Audit locked dependencies
 
 Run both ecosystem audits separately so findings can be reviewed:
@@ -164,6 +170,12 @@ commit-addressed `sha-<full-commit>` candidate tags. Before tagging:
 4. Remove the disposable project, volume, network, and secret file. Record the
    manifest digest and generic result in the release evidence.
 
+Documentation-only pushes under `docs/` or to `README.md` do not trigger the image
+workflow. A release-preparation merge must include the package-version changes in
+backend and frontend metadata, which are outside that ignore set and therefore
+publish the required candidate. GitHub does not evaluate path filters for tag
+pushes.
+
 ## 8. Tag and release
 
 After every pre-tag release-record field is final, create and push the annotated tag:
@@ -193,6 +205,11 @@ released artifact and do not reproduce private release evidence. Publish the Git
 Release only after `1.0.1`, `1.0`, `1`, and `latest` resolve to the expected release
 commit, the `sha-<full-commit>` candidate still resolves to its recorded pre-tag
 digest, and the tagged clean-install smoke passes.
+
+For subsequent releases, do not create a post-release evidence commit. Record the
+final digest, publication time, alias verification, and tagged-image smoke only in
+the GitHub Release. This avoids advancing `main` and publishing a new candidate
+image solely to describe the release that preceded it.
 
 If any post-tag check fails, do not move, delete, or reuse the published tag.
 Document the failure, fix forward through the normal protected-`main` workflow, and

--- a/docs/releases/v1.0.1.md
+++ b/docs/releases/v1.0.1.md
@@ -1,10 +1,12 @@
 # Tasterr v1.0.1 release evidence
 
-- Release date: pending GitHub Release
+- Release date: 2026-07-26
 - Git tag: `v1.0.1`
-- Evidence status: release preparation. This patch is the fix-forward for the
-  `v1.0.0` SHA-alias publication defect and will be Tasterr's first announced
-  GitHub Release.
+- Evidence status: published as Tasterr's first announced
+  [GitHub Release](https://github.com/ZacharyArthur/tasterr/releases/tag/v1.0.1).
+  This patch fixes forward from the `v1.0.0` SHA-alias publication defect.
+- This one-time closeout predates the pre-tag-only evidence process documented for
+  subsequent releases.
 
 ## Scope
 
@@ -21,13 +23,16 @@
 
 ## Completed verification
 
-- All required pull-request jobs for pull request 4 passed: `check`, `e2e`, and
-  `container-smoke`.
-- Post-merge `just release-check` passed on 2026-07-26 with 445 backend tests,
-  64 frontend tests, current generated API types, the production frontend build,
-  the Chromium login/home/detail/request journey, and production container health,
-  private logs, hardened headers, SPA serving, non-root runtime, and volume
-  persistence.
+- All required `check`, `e2e`, and `container-smoke` jobs passed for pull requests
+  4 and 5. Pull request 5's first container-smoke attempt timed out while fetching
+  the pinned Python and Node base-image tags from Docker Hub; its failed log reached
+  no repository test, and the failed job passed on retry.
+- Pull request 5 was squash-merged to `main` as
+  `f0bf7f7229530b548ef36ace046f855b652e608a`. Post-merge `just release-check`
+  passed on 2026-07-26 with 445 backend tests, 64 frontend tests, current generated
+  API types, the production frontend build, the Chromium
+  login/home/detail/request journey, and production container health, private
+  logs, hardened headers, SPA serving, non-root runtime, and volume persistence.
 - The public `sha-c27a6e02b1d96420b905ec3a9bfa6c5b8da43b51` intermediate candidate
   has OCI digest
   `sha256:1687f53ce4578f783f4b45e2d5b9b7a88f1a3d165310c2498fca09042de4f3ea`
@@ -35,6 +40,13 @@
 - Anonymous inspection confirmed that `1.0.0` and
   `sha-b777590dd07a404e67d00512ae8860d8671d17a5` remain unchanged at
   `sha256:29da7914dbc804b012b54c785c807ed85096d778fad888474af26bfca910976a`.
+- The final pre-tag
+  `sha-f0bf7f7229530b548ef36ace046f855b652e608a` candidate has OCI digest
+  `sha256:4bc2e62e12488deef0f93d8352f607704e4a73227d6a58495c47c4b9dcf305f7`
+  and contains `linux/amd64` and `linux/arm64` manifests. An anonymous pull and
+  clean Compose installation passed health, SPA, non-root UID 999, bundled-license,
+  SQLite initialization, and named-volume persistence checks. All disposable
+  resources and configuration were removed.
 
 ## Dependency audit
 
@@ -49,17 +61,22 @@
   The suggested forced downgrade of `openapi-typescript` is breaking and is not
   applicable; upgrade when the compatible upstream dependency tree is patched.
 
-## Pre-tag requirements
+## Publication
 
-- Squash-merge the version and release-documentation update through protected
-  `main`.
-- Rerun `just release-check`, inspect the resulting commit-SHA candidate, and
-  perform its credential-free clean-install and persistence smoke.
-- Create and push the annotated `v1.0.1` tag only after the candidate passes.
-- Confirm `1.0.1`, `1.0`, `1`, and `latest` resolve to the tagged release while
-  the commit-SHA candidate retains its pre-tag digest.
-- Perform a credential-free clean installation of `1.0.1` before publishing the
-  GitHub Release.
+- The annotated `v1.0.1` tag points to
+  `f0bf7f7229530b548ef36ace046f855b652e608a`. Its image workflow passed tag
+  ancestry verification, native container smoke, and multi-architecture publishing.
+- `1.0.1`, `1.0`, `1`, and `latest` resolve to
+  `sha256:a191b896b530e631c9197bee598b6ddb236d1daf0d1ea94e83ab0477fd64b6a9`
+  with `linux/amd64` and `linux/arm64` manifests. The commit-SHA candidate retained
+  its recorded pre-tag digest.
+- An anonymous pull and clean Compose installation of `1.0.1` passed release-label,
+  health, SPA, non-root UID 999, bundled-license, SQLite initialization, and
+  named-volume persistence checks. All disposable resources and configuration were
+  removed.
+- The non-draft, non-prerelease GitHub Release was published at
+  <https://github.com/ZacharyArthur/tasterr/releases/tag/v1.0.1> with the verified
+  stable digest and installation/upgrade guidance.
 
 ## Live-contract disposition
 


### PR DESCRIPTION
## What / why

Close the one-time v1.0.1 release evidence with the verified commit, image
digests, anonymous installation results, and GitHub Release URL. Make future
release evidence pre-tag-only, keep post-tag facts in the GitHub Release, and
prevent docs/README-only main pushes from publishing unnecessary candidate images
without filtering required PR checks or tag publication.

## Spec

- OpenSpec change: `n/a: release workflow and evidence maintenance`
- [x] No archive required

## Checklist

- [x] `just check` passes locally
- [x] Workflow and release evidence reviewed
- [x] Title is the Conventional Commit subject for the squash