### PR TITLE
docs: add contributor and issue reporting guides

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,76 @@
+name: Bug report
+description: Report reproducible behavior that is not working as expected
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Search existing issues first and try the
+        latest stable patch release when practical.
+
+        **Do not include API keys, credentials, session data, private URLs,
+        household identities, viewing history, or database contents.** Report
+        security vulnerabilities privately through the
+        [security policy](https://github.com/ZacharyArthur/tasterr/security/policy).
+
+  - type: input
+    id: version
+    attributes:
+      label: Tasterr version
+      description: Provide the image tag, release version, or commit SHA.
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Describe the actual behavior and what you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest reliable sequence that demonstrates the problem.
+      placeholder: |
+        1. Open ...
+        2. Select ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >-
+        Include the relevant browser, operating system, and deployment method, plus
+        the Seerr version when applicable. Redact hostnames and addresses.
+      placeholder: |
+        Browser:
+        Operating system:
+        Deployment:
+        Seerr version (if relevant):
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Paste only the smallest relevant excerpt after removing secrets and private data.
+      render: shell
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues for this problem.
+          required: true
+        - label: I removed secrets, credentials, private URLs, and household data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Configuration and troubleshooting
+    url: https://github.com/ZacharyArthur/tasterr/blob/main/docs/CONFIGURATION.md#troubleshooting
+    about: Check the setup, operations, and troubleshooting guidance.
+  - name: Security vulnerability
+    url: https://github.com/ZacharyArthur/tasterr/security/policy
+    about: Read the security policy and report vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Suggest an improvement grounded in a concrete use case
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the problem before prescribing an implementation. Tasterr favors
+        small, maintainable features that fit its self-hosted household-media scope.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to accomplish, and what prevents it today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe the behavior you would find useful.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Alternatives or additional context
+      description: >-
+        Note workarounds or simpler alternatives, and add examples or screenshots
+        when helpful. Do not include secrets or private household data.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues for this request.
+          required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing to Tasterr
+
+Thanks for helping improve Tasterr. Small, focused changes are the easiest to review
+and maintain.
+
+## Before you start
+
+- Search existing issues before opening a new one.
+- Use the [issue chooser](https://github.com/ZacharyArthur/tasterr/issues/new/choose)
+  for bug reports and feature requests.
+- Report vulnerabilities privately as described in [SECURITY.md](SECURITY.md).
+- Open a feature request before investing in a substantial change so its scope can
+  be agreed first.
+
+## Development environment
+
+All development and checks run inside the repository's devcontainer. Docker is
+required. Keep project dependencies on the container volumes rather than installing
+`backend/.venv` or `frontend/node_modules` on the host.
+
+In VS Code, use **Dev Containers: Reopen in Container**. A headless setup also
+requires Node.js for the devcontainer CLI:
+
+```console
+npx @devcontainers/cli up --workspace-folder .
+npx @devcontainers/cli exec --workspace-folder . just check
+```
+
+Inside the devcontainer, the common commands are:
+
+```console
+just dev-backend  # FastAPI development server
+just dev-frontend # Vite development server
+just types        # regenerate frontend API types after schema changes
+just check        # full required quality gate
+```
+
+## Change workflow
+
+New features, behavior changes, and architecture decisions require an OpenSpec change
+under `openspec/changes/` before implementation. Start with a feature request; after
+its scope is agreed, the maintainer will coordinate the OpenSpec artifacts. Bug fixes
+that restore specified behavior, documentation, chores, and dependency updates do
+not require an OpenSpec change.
+
+Use a focused branch:
+
+- `change/<openspec-change-id>` for OpenSpec changes
+- `fix/<slug>` for bug fixes
+- `chore/<slug>` for documentation, maintenance, and dependency updates
+
+Use Conventional Commit subjects (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`, or
+`chore:`), written imperatively and no longer than 72 characters.
+
+## Implementation expectations
+
+- Prefer the smallest maintainable solution; new dependencies need clear
+  justification.
+- Preserve the boundaries and security invariants in
+  [the architecture guide](docs/ARCHITECTURE.md) and
+  [the security checklist](docs/SECURITY.md).
+- Keep backend and frontend types aligned. Frontend API types are generated from the
+  backend OpenAPI schema rather than maintained separately.
+- Add or update tests for changed behavior.
+
+## Pull requests
+
+Before opening a pull request:
+
+1. Run `just check` inside the devcontainer.
+2. Archive a completed OpenSpec change on its branch, when applicable.
+3. Review the full diff for secrets, credentials, private URLs, household data, and
+   unrelated changes.
+4. Complete the pull request template. Use the Conventional Commit subject as the
+   pull request title.
+
+The required PR checks are `check`, `e2e`, and `container-smoke`. To reproduce all
+three locally, install Chromium once inside the devcontainer and run:
+
+```console
+cd frontend && npx playwright install --with-deps chromium
+cd ..
+just release-check
+```
+
+Pull requests are squash-merged after those checks pass.
+
+By contributing, you agree that your contribution is licensed under the repository's
+[AGPL-3.0-only license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ specific LAN bind only when direct household-network access is intentional.
   taste flows, storage, caches, and generated API types.
 - [Security policy](SECURITY.md): supported releases and private vulnerability
   reporting. The developer threat model lives in [docs/SECURITY.md](docs/SECURITY.md).
+- [Contributing guide](CONTRIBUTING.md): issue reporting, development setup, change
+  workflow, and pull request expectations.
 - [Release procedure](docs/RELEASING.md): deterministic checks, audits, live
   contracts, image verification, and rollback.
 


### PR DESCRIPTION
## What / why

Add a concise contribution guide and structured GitHub issue forms for bug reports
and feature requests. This makes the development workflow, security expectations,
and required PR checks discoverable while keeping issue triage consistent.

## Spec

- OpenSpec change: `n/a: documentation and repository configuration`
- [x] Change archived on this branch (if applicable)

## Checklist

- [x] `just check` passes locally
- [x] Title is the Conventional Commit subject for the squash
