### PR TITLE
chore: harden repository and release automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+
+multi-ecosystem-groups:
+  dependencies:
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+
+updates:
+  - package-ecosystem: uv
+    directory: /backend
+    patterns:
+      - "*"
+    multi-ecosystem-group: dependencies
+
+  - package-ecosystem: npm
+    directory: /frontend
+    patterns:
+      - "*"
+    multi-ecosystem-group: dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    patterns:
+      - "*"
+    multi-ecosystem-group: dependencies
+
+  - package-ecosystem: docker
+    directories:
+      - /
+      - /.devcontainer
+    patterns:
+      - "*"
+    multi-ecosystem-group: dependencies
+
+  - package-ecosystem: devcontainers
+    directory: /
+    patterns:
+      - "*"
+    multi-ecosystem-group: dependencies

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -6,9 +6,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -42,6 +47,7 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -82,6 +88,7 @@ jobs:
 
   container-smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -13,9 +13,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: image-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -41,8 +46,11 @@ jobs:
     needs: smoke
     if: github.ref == 'refs/heads/main' || (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-'))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
+      attestations: write
       contents: read
+      id-token: write
       packages: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -77,6 +85,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish
+        id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
@@ -86,3 +95,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Attest image
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # AI tool artifacts (AGENTS.md, CLAUDE.md, and openspec/ ARE committed)
 .claude/
+.agents/
 .cursor/
 .codex/
 .gemini/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,9 +97,9 @@ dependencies). Walk the relevant checklist whenever touching `api/`, `auth/`,
 
 ## Git workflow
 
-- `main` is always releasable. Branch per change: `change/<openspec-change-id>`;
-  `fix/<slug>` / `chore/<slug>` for non-spec work. Trivial fixes (typos, docs,
-  dep bumps) may commit directly to `main`.
+- `main` is always releasable. Every change lands through a pull request. Branch per
+  change: `change/<openspec-change-id>`; `fix/<slug>` / `chore/<slug>` for non-spec
+  work. Trivial fixes (typos, docs, dep bumps) may skip OpenSpec, not the branch/PR.
 - **Conventional Commits**: `feat:` `fix:` `refactor:` `docs:` `test:` `chore:`,
   imperative subject <= 72 chars.
 - PRs: **squash merge**, self-approved. PR title = the Conventional Commit subject

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,22 @@
+# Code of Conduct
+
+## Our standard
+
+Be respectful, constructive, and considerate. Discuss ideas and behavior without
+attacking people. Harassment, discrimination, threats, sexualized attention,
+doxxing, and sustained disruptive behavior are not acceptable.
+
+## Scope
+
+This standard applies to repository issues, pull requests, and other project spaces,
+as well as public interactions made on behalf of Tasterr.
+
+## Enforcement
+
+The maintainer may edit or remove contributions, close threads, or temporarily or
+permanently restrict participation when behavior violates this standard.
+
+Use GitHub's private report-abuse tools for confidential or urgent concerns. Raise
+other concerns in the repository only when doing so will not expose private or
+sensitive information. Good-faith reports will be handled as privately and promptly
+as the available channel permits.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to Tasterr
 
 Thanks for helping improve Tasterr. Small, focused changes are the easiest to review
-and maintain.
+and maintain. Participation is governed by the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Before you start
 
@@ -74,8 +74,9 @@ Before opening a pull request:
 4. Complete the pull request template. Use the Conventional Commit subject as the
    pull request title.
 
-The required PR checks are `check`, `e2e`, and `container-smoke`. To reproduce all
-three locally, install Chromium once inside the devcontainer and run:
+The required PR checks are `check`, `e2e`, `container-smoke`, and GitHub's `CodeQL`
+analysis. To reproduce the three repository-owned checks locally, install Chromium
+once inside the devcontainer and run:
 
 ```console
 cd frontend && npx playwright install --with-deps chromium

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
-# Stage 1: build the SPA
-FROM node:24-slim AS frontend
+# Keep uv on a FROM line so Dependabot can update its digest.
+FROM ghcr.io/astral-sh/uv:0.11@sha256:df4cae8f3a96d175e2e5f992e597550000edbe78fdc2594d5cd8de1a217f504c AS uv
+
+# Build the SPA.
+FROM node:24-slim@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d AS frontend
 WORKDIR /build
 COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci
 COPY frontend/ ./
 RUN npm run build
 
-# Stage 2: python runtime serves the API and the built SPA
-FROM python:3.13-slim
-COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /uvx /usr/local/bin/
+# Serve the API and built SPA from the Python runtime.
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91
+COPY --from=uv /uv /uvx /usr/local/bin/
 
 ENV PYTHONUNBUFFERED=1 \
     UV_COMPILE_BYTECODE=1 \

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ specific LAN bind only when direct household-network access is intentional.
   reporting. The developer threat model lives in [docs/SECURITY.md](docs/SECURITY.md).
 - [Contributing guide](CONTRIBUTING.md): issue reporting, development setup, change
   workflow, and pull request expectations.
+- [Code of Conduct](CODE_OF_CONDUCT.md): expected behavior and enforcement.
 - [Release procedure](docs/RELEASING.md): deterministic checks, audits, live
   contracts, image verification, and rollback.
 

--- a/backend/tests/test_container_contract.py
+++ b/backend/tests/test_container_contract.py
@@ -1,6 +1,7 @@
 """Static and Compose-rendered contracts for the production container smoke."""
 
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -157,8 +158,19 @@ def test_optional_override_requires_network_name(tmp_path: Path) -> None:
 def test_dockerfile_and_smoke_are_fail_closed() -> None:
     dockerfile = DOCKERFILE.read_text(encoding="utf-8")
     smoke = SMOKE.read_text(encoding="utf-8")
+    from_lines = [line for line in dockerfile.splitlines() if line.startswith("FROM ")]
+    image_refs = [line.split()[1] for line in from_lines]
+    stage_names = {line.split()[-1] for line in from_lines if " AS " in line}
+    copy_sources = {
+        line.removeprefix("COPY --from=").split()[0]
+        for line in dockerfile.splitlines()
+        if line.startswith("COPY --from=")
+    }
 
     assert "USER app" in dockerfile
+    assert len(image_refs) == 3
+    assert all(re.fullmatch(r"[^@\s]+@sha256:[0-9a-f]{64}", ref) for ref in image_refs)
+    assert copy_sources <= stage_names
     assert "ARG " not in dockerfile
     assert "npm ci" in dockerfile
     assert dockerfile.count("uv sync --frozen") == 2

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -45,10 +45,12 @@ def test_readme_links_every_living_operator_document() -> None:
         "docs/CONFIGURATION.md",
         "docs/ARCHITECTURE.md",
         "SECURITY.md",
+        "CODE_OF_CONDUCT.md",
         "docs/SECURITY.md",
         "docs/RELEASING.md",
     ):
         assert f"]({target})" in readme
+        assert (ROOT / target).is_file()
     assert "docker compose up -d --build" in readme
     assert "SEERR_INTERNAL_URL" in readme
     assert "A shared Docker network is not required" in readme
@@ -82,7 +84,7 @@ def test_readme_links_every_living_operator_document() -> None:
     evidence = _read(DOCS / "releases" / "v1.0.1.md")
     assert "OWNER/REPOSITORY" not in readme + releasing + evidence
     assert "empty **public** `ZacharyArthur/tasterr` repository" in releasing
-    assert "`check`, `e2e`, and `container-smoke`" in releasing
+    assert "`check`, `e2e`, `container-smoke`, and `CodeQL`" in releasing
     assert "leave the existing `sha-<full-commit>` candidate unchanged" in releasing
     assert "pin the `1.0.1` digest" in releasing
     assert "GitHub Release is the authoritative post-tag record" in releasing
@@ -90,6 +92,9 @@ def test_readme_links_every_living_operator_document() -> None:
     assert "do not move, delete, or reuse the published tag" in releasing
     assert "Public repositories support this ruleset on GitHub Free" in releasing
     assert "private vulnerability reporting" in releasing
+    assert "immutable releases" in releasing
+    assert "gh attestation verify" in releasing
+    assert "predates image attestations and immutable GitHub Releases" in evidence
     assert "do not use a create-and-push shortcut" in releasing
 
 

--- a/backend/tests/test_workflows.py
+++ b/backend/tests/test_workflows.py
@@ -11,6 +11,7 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = ROOT / ".github" / "workflows"
+DEPENDABOT = ROOT / ".github" / "dependabot.yml"
 ACTION_REF = re.compile(r"uses:\s+[^@\s]+@(?P<sha>[0-9a-f]{40})\s+#\s+v[^\s]+\s*$")
 
 
@@ -27,6 +28,29 @@ def test_workflows_are_valid_yaml() -> None:
         assert yaml.safe_load(path.read_text(encoding="utf-8")) is not None
 
 
+def test_dependabot_groups_every_repository_ecosystem_weekly() -> None:
+    config = yaml.safe_load(DEPENDABOT.read_text(encoding="utf-8"))
+    group = config["multi-ecosystem-groups"]["dependencies"]
+
+    assert group["schedule"] == {"interval": "weekly"}
+    assert group["commit-message"]["prefix"] == "chore(deps)"
+    assert {
+        (
+            update["package-ecosystem"],
+            tuple(update.get("directories") or [update["directory"]]),
+        )
+        for update in config["updates"]
+    } == {
+        ("uv", ("/backend",)),
+        ("npm", ("/frontend",)),
+        ("github-actions", ("/",)),
+        ("docker", ("/", "/.devcontainer")),
+        ("devcontainers", ("/",)),
+    }
+    assert all(update["patterns"] == ["*"] for update in config["updates"])
+    assert all(update["multi-ecosystem-group"] == "dependencies" for update in config["updates"])
+
+
 def test_every_third_party_action_is_immutable_and_versioned() -> None:
     for path in WORKFLOWS.glob("*.yml"):
         uses_lines = [
@@ -41,12 +65,20 @@ def test_every_third_party_action_is_immutable_and_versioned() -> None:
 
 def test_pull_request_gate_runs_all_blocking_local_contracts() -> None:
     gate = _text("gate.yml")
+    jobs = yaml.safe_load(gate)["jobs"]
 
     assert "pull_request:" in gate
     assert "\n  push:" not in gate
     assert "paths:" not in gate
     assert "paths-ignore:" not in gate
     assert "permissions:\n  contents: read" in gate
+    assert "group: gate-${{ github.event.pull_request.number }}" in gate
+    assert "cancel-in-progress: true" in gate
+    assert {name: job["timeout-minutes"] for name, job in jobs.items()} == {
+        "check": 15,
+        "e2e": 15,
+        "container-smoke": 15,
+    }
     assert "  check:" in gate
     assert "  e2e:" in gate
     assert "  container-smoke:" in gate
@@ -66,12 +98,27 @@ def test_image_workflow_publishes_only_after_native_smoke() -> None:
     assert 'tags:\n      - "v*"' in image
     assert push_config["paths-ignore"] == ["docs/**", "README.md"]
     assert "permissions:\n  contents: read" in image
+    assert image_config["concurrency"] == {
+        "group": "image-${{ github.ref }}",
+        "cancel-in-progress": False,
+    }
+    assert {name: job["timeout-minutes"] for name, job in image_config["jobs"].items()} == {
+        "smoke": 15,
+        "publish": 30,
+    }
     assert "needs: smoke" in image
     assert image.index("just container-smoke") < image.index("docker/login-action")
     assert "fetch-depth: 0" in image
     assert "^v[0-9]+\\.[0-9]+\\.[0-9]+$" in image
     assert 'git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main' in image
     assert "packages: write" in image
+    assert "attestations: write" in image
+    assert "id-token: write" in image
+    assert "id: build" in image
+    assert "actions/attest@" in image
+    assert "subject-name: ghcr.io/${{ github.repository }}\n" in image
+    assert "subject-digest: ${{ steps.build.outputs.digest }}" in image
+    assert "push-to-registry: true" in image
     assert "platforms: linux/amd64,linux/arm64" in image
     assert "type=raw,value=main" in image
     sha_rules = [line.strip() for line in image.splitlines() if line.strip().startswith("type=sha")]

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -5,6 +5,8 @@ This procedure is for stable v1 releases. The current package version is
 only after all release changes are squash-merged to protected `main`. The published
 `v1.0.0` tag is retained for provenance, but no GitHub Release was announced for it;
 `v1.0.1` is the immutable-tag fix-forward and first announced release.
+The v1.0.1 image and GitHub Release predate image attestations and immutable GitHub
+Releases; those guarantees apply to later publications.
 
 ## 1. Prepare the required devcontainer
 
@@ -29,10 +31,11 @@ Confirm Uvicorn access logs are disabled and the deployment proxy omits or redac
 request query strings.
 
 Before any public announcement, enable GitHub private vulnerability reporting,
-secret scanning (including push protection where available), and Dependabot alerts.
-Confirm `.env.example` and test fixtures contain invented placeholders only, and
-review staged files for live URLs, identities, viewing data, credentials, and
-generated failure artifacts.
+secret scanning (including push protection where available), Dependabot alerts and
+updates, and immutable releases. Confirm an active `v*` tag ruleset blocks updates
+and deletion. Confirm `.env.example` and test fixtures contain invented placeholders
+only, and review staged files for live URLs, identities, viewing data, credentials,
+and generated failure artifacts.
 
 ## 3. Run deterministic checks
 
@@ -129,23 +132,28 @@ For the first publication, use this order:
    `fastapi`, `react`, and `docker`. The source history must have passed the
    documented secret review before this public creation.
 2. Enable Issues. Disable Wiki, Projects, and Discussions. Allow squash merging
-   only, enable automatic head-branch deletion, keep the default `GITHUB_TOKEN`
-   permissions read-only, and leave workflow pull-request creation/approval
-   disabled. Require external Actions to be pinned to full commit SHAs.
+   only with pull-request titles as the default squash-commit title, enable automatic
+   head-branch deletion, keep the default `GITHUB_TOKEN` permissions read-only, and
+   leave workflow pull-request creation/approval disabled. Require external Actions
+   to be pinned to full commit SHAs.
 3. Disable Actions before the first push. Push the existing base `main` and the
    reviewed `change/v1-public-release-readiness` branch, then re-enable Actions.
    This prevents the old `main` commit from publishing a container during import.
-4. Enable the dependency graph, Dependabot alerts, Dependabot security updates,
-   secret scanning, push protection, and private vulnerability reporting. The image
-   workflow's publishing job is the only job granted `packages: write`; all other
-   workflow permissions remain read-only.
-5. Open the readiness PR against `main` and let `check`, `e2e`, and
-   `container-smoke` report at least once.
+4. Enable the dependency graph, Dependabot alerts and security updates, secret
+   scanning, push protection, private vulnerability reporting, and immutable
+   releases. Confirm GitHub accepts the committed Dependabot version-update
+   configuration. The image workflow's publishing job is the only job granted
+   package, attestation, and OIDC write permissions; all other workflow permissions
+   remain read-only.
+5. Open the readiness PR against `main` and let `check`, `e2e`, `container-smoke`,
+   and `CodeQL` report at least once.
 6. Configure an active `main` ruleset that requires a pull request with zero approving
-   reviews, successful `check`, `e2e`, and `container-smoke` jobs, linear history,
-   conversation resolution, and blocks force pushes and deletion. Restrict merge
-   type to squash. Public repositories support this ruleset on GitHub Free.
-7. Wait for all three required jobs, self-review, resolve every conversation, and
+   reviews, successful `check`, `e2e`, `container-smoke`, and `CodeQL` jobs, linear
+   history, conversation resolution, and blocks force pushes and deletion. Restrict
+   merge type to squash. Public repositories support this ruleset on GitHub Free.
+7. Configure an active `v*` tag ruleset that permits creation but blocks tag updates
+   and deletion without bypass.
+8. Wait for all four required jobs, self-review, resolve every conversation, and
    squash merge. Do not tag the unmerged change branch.
 
 Update local `main` to the squash commit and rerun the deterministic release check:
@@ -159,7 +167,13 @@ npx @devcontainers/cli exec --workspace-folder . just release-check
 The image workflow on the merged `main` commit publishes public `main` and
 commit-addressed `sha-<full-commit>` candidate tags. Before tagging:
 
-1. Inspect the candidate manifest and confirm both `linux/amd64` and `linux/arm64`.
+1. Inspect the candidate manifest, confirm both `linux/amd64` and `linux/arm64`, and
+   verify its GitHub artifact attestation:
+
+   ```console
+   gh attestation verify oci://ghcr.io/zacharyarthur/tasterr:sha-<full-commit> -R ZacharyArthur/tasterr
+   ```
+
 2. Confirm that the GHCR package is linked to the public repository and explicitly
    public; repository and package visibility are separate controls.
 3. From an environment with no GHCR credentials, verify an anonymous pull. Then use
@@ -193,18 +207,26 @@ manifest and confirm both platforms:
 npx @devcontainers/cli exec --workspace-folder . docker buildx imagetools inspect ghcr.io/zacharyarthur/tasterr:1.0.1
 ```
 
+The historical v1.0.1 image has no attestation. For subsequent releases, substitute
+the release version and verify the stable image attestation:
+
+```console
+gh attestation verify oci://ghcr.io/zacharyarthur/tasterr:<version> -R ZacharyArthur/tasterr
+```
+
 Perform a fresh install in an empty directory with a new external network, disposable
 `.env`, and new Compose project. Set
 `TASTERR_IMAGE=ghcr.io/zacharyarthur/tasterr:1.0.1`, run `docker compose pull` and
 `docker compose up -d --no-build`, then verify health, SPA serving, non-root uid, and
 named-volume persistence. Delete every disposable resource after verification.
 
-Publish release notes only after the manifest and fresh install pass. Summarize user-
-visible changes, upgrade steps, and known limitations; pin the `1.0.1` digest as the
-released artifact and do not reproduce private release evidence. Publish the GitHub
-Release only after `1.0.1`, `1.0`, `1`, and `latest` resolve to the expected release
-commit, the `sha-<full-commit>` candidate still resolves to its recorded pre-tag
-digest, and the tagged clean-install smoke passes.
+Publish release notes only after the applicable manifest, attestation, and fresh
+install checks pass. Summarize user-visible changes, upgrade steps, and known
+limitations; then pin the `1.0.1` digest as the released artifact without reproducing
+private evidence. The historical v1.0.1 GitHub Release is mutable. For subsequent
+releases, publish with repository immutability enabled only after every stable alias
+resolves to the expected release commit, the `sha-<full-commit>` candidate still
+resolves to its recorded pre-tag digest, and the tagged clean-install smoke passes.
 
 For subsequent releases, do not create a post-release evidence commit. Record the
 final digest, publication time, alias verification, and tagged-image smoke only in

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -87,11 +87,13 @@ relevant checklists below (enforced via `openspec/config.yaml` rules).
 - [ ] New dependency: justified against the AGENTS.md stack slate in design.md; check
       maintenance status and provenance before adding.
 - [ ] `uv.lock` / `package-lock.json` updated and committed together with the change.
-- [ ] Dockerfile: non-root user, minimal base image, no secrets in layers or build args.
+- [ ] Dockerfile: non-root user, minimal digest-pinned base images, no secrets in
+      layers or build args.
 - [ ] Native container smoke proves health, SPA, non-root uid, named-volume
       persistence, isolated placeholder configuration, and unconditional cleanup.
 - [ ] Every third-party workflow action is pinned to a reviewed full commit SHA;
-      permissions default read-only and package write exists only on the publish job.
+      permissions default read-only, and package/attestation/OIDC write exists only
+      on the publish job.
 
 ### Logging and release evidence
 
@@ -111,6 +113,8 @@ relevant checklists below (enforced via `openspec/config.yaml` rules).
 - [ ] GitHub private vulnerability reporting is enabled.
 - [ ] Secret scanning and push protection (where available) are enabled.
 - [ ] Dependabot alerts are enabled and triaged.
+- [ ] Immutable releases are enabled and a `v*` tag ruleset blocks release-tag
+      updates and deletion.
 - [ ] `.env.example`, fixtures, history, staged files, and release notes are reviewed
       for live secrets, URLs, identities, and household data.
 - [ ] Root licensing, package metadata, published image license text, and the public
@@ -125,8 +129,9 @@ relevant checklists below (enforced via `openspec/config.yaml` rules).
 
 - [ ] `just release-check` passes in the devcontainer (ordinary gate + browser +
       native container smoke).
-- [ ] GHCR workflow permissions/tags are reviewed; stable manifests and a fresh
-      registry-image deployment are verified before announcement.
+- [ ] GHCR workflow permissions/tags are reviewed; stable manifests, image
+      attestations, and a fresh registry-image deployment are verified before
+      announcement.
 
 ## Working notes
 

--- a/docs/releases/v1.0.1.md
+++ b/docs/releases/v1.0.1.md
@@ -77,6 +77,9 @@
 - The non-draft, non-prerelease GitHub Release was published at
   <https://github.com/ZacharyArthur/tasterr/releases/tag/v1.0.1> with the verified
   stable digest and installation/upgrade guidance.
+- This publication predates image attestations and immutable GitHub Releases. The
+  protected `v1.0.1` tag remains the fixed source reference; the newer guarantees
+  begin with the next published image and GitHub Release.
 
 ## Live-contract disposition
 

--- a/openspec/specs/release-readiness/spec.md
+++ b/openspec/specs/release-readiness/spec.md
@@ -64,8 +64,8 @@ The root `SECURITY.md` SHALL state the supported release line, direct vulnerabil
 reports to GitHub private vulnerability reporting, tell reporters not to disclose
 secrets or household data, and describe the acknowledgement/remediation expectations.
 The release procedure SHALL require private vulnerability reporting, secret scanning,
-and Dependabot alerts to be enabled before a public repository or package is
-announced.
+Dependabot alerts and updates, immutable releases, and protected version tags to be
+enabled before a public repository or package is announced.
 
 #### Scenario: Reporter finds a private channel
 - **WHEN** a security researcher opens the repository security policy
@@ -74,8 +74,8 @@ announced.
 
 #### Scenario: Public release checks repository security features
 - **WHEN** the operator prepares to make the repository or package public
-- **THEN** the release checklist requires private reporting, secret scanning, and
-  dependency alerts to be enabled first
+- **THEN** the release checklist requires private reporting, secret scanning,
+  dependency maintenance, immutable releases, and protected version tags first
 
 ### Requirement: Deterministic pre-release verification is repeatable
 
@@ -128,13 +128,13 @@ announcement, every template owner/repository marker MUST be replaced by the fin
 coordinate. The first repository bootstrap SHALL begin with an empty public
 repository and Actions disabled while the existing base and reviewed change branches
 are imported. The readiness change SHALL merge through the required `check`, `e2e`,
-and `container-smoke` pull-request gates before the main workflow publishes an
-immutable candidate. The release procedure SHALL verify that candidate's
-multi-architecture manifest, public package visibility, and anonymous clean
-installation before creating the stable tag. It SHALL verify the tagged image's
-`1.0.0`, `1.0`, `1`, `latest`, and immutable SHA tags and fresh deployment before
-the GitHub Release, and SHALL document rollback by immutable image digest and
-validated SQLite backup.
+`container-smoke`, and `CodeQL` pull-request gates before the main workflow publishes
+an immutable candidate with verifiable build provenance. The release procedure SHALL
+verify that candidate's multi-architecture manifest, artifact attestation, public
+package visibility, and anonymous clean installation before creating the stable tag.
+It SHALL verify the tagged image's `1.0.0`, `1.0`, `1`, `latest`, and immutable SHA
+tags, artifact attestation, and fresh deployment before the immutable GitHub Release,
+and SHALL document rollback by immutable image digest and validated SQLite backup.
 
 #### Scenario: First stable tag follows the atomic merge
 
@@ -167,5 +167,5 @@ validated SQLite backup.
 
 - **WHEN** the stable image workflow finishes for `v1.0.0`
 - **THEN** the operator confirms every documented stable and immutable tag, verifies
-  amd64 and arm64 manifests, and completes a fresh-start smoke from the tagged GHCR
-  image before publishing the GitHub Release
+  amd64 and arm64 manifests plus the image attestation, and completes a fresh-start
+  smoke from the tagged GHCR image before publishing the immutable GitHub Release


### PR DESCRIPTION
## What / why

Harden repository maintenance and release automation with grouped dependency
updates, bounded workflow execution, digest-pinned production bases, and verifiable
container-image provenance.

Align contributor and release documentation with the enforced pull-request workflow,
add a minimal code of conduct, and protect future releases and version tags through
the corresponding GitHub settings.

## Spec

- OpenSpec change: `n/a: repository and release chore`
- [x] Change archived on this branch (not applicable)

## Validation

- [x] `just check`
- [x] `just e2e`
- [x] `just container-smoke`
- [x] Strict OpenSpec validation

## Checklist

- [x] `just check` passes locally
- [x] Title is the Conventional Commit subject for the squash