### PR TITLE
fix: improve rail discovery coverage

### DIFF
--- a/backend/src/tasterr/rails/composer.py
+++ b/backend/src/tasterr/rails/composer.py
@@ -176,14 +176,11 @@ async def _hero_slide(ctx: RailContext, summary: MediaSummary) -> HeroSlide:
 
 
 def _home_genre_providers(genre_map: dict[str, int]) -> list[RailProvider]:
-    providers: list[RailProvider] = []
-    for name in GENRE_PICKS:
-        genre_id = genre_map.get(name)
-        if genre_id is not None:
-            providers.append(genre_provider(genre_id, name, "movie"))
-        if len(providers) >= HOME_GENRE_COUNT:
-            break
-    return providers
+    return [genre_provider(genre_map[name], name, "movie") for name in _home_genre_names(genre_map)]
+
+
+def _home_genre_names(genre_map: dict[str, int]) -> list[str]:
+    return [name for name in GENRE_PICKS if name in genre_map][:HOME_GENRE_COUNT]
 
 
 async def _extended_providers(ctx: RailContext) -> list[RailProvider]:
@@ -197,7 +194,7 @@ async def _extended_providers(ctx: RailContext) -> list[RailProvider]:
     movie_map, tv_map = await asyncio.gather(
         _safe_genre_map(ctx.catalog, "movie"), _safe_genre_map(ctx.catalog, "tv")
     )
-    featured = set(GENRE_PICKS)
+    featured = set(_home_genre_names(movie_map))
     providers += [
         genre_provider(gid, name, "movie")
         for name, gid in movie_map.items()

--- a/backend/src/tasterr/rails/registry.py
+++ b/backend/src/tasterr/rails/registry.py
@@ -184,7 +184,7 @@ def home_providers() -> list[RailProvider]:
         ),
         RailProvider(
             "recently-added",
-            "Recently Added",
+            "Recent Releases",
             "standard",
             lambda ctx: ctx.catalog.discover(
                 "movie",
@@ -244,7 +244,7 @@ def service_provider(service: ServiceOption) -> RailProvider:
         return await ctx.catalog.discover(
             "movie",
             sort_by="primary_release_date.desc",
-            release_gte=_days_ago(150),
+            release_gte=_days_ago(365),
             release_lte=_today(),
             min_votes=3,
             service_ids=[service.provider_id],
@@ -252,7 +252,7 @@ def service_provider(service: ServiceOption) -> RailProvider:
 
     return RailProvider(
         f"service-{service.provider_id}",
-        f"New on {service.name}",
+        f"Recent Releases on {service.name}",
         "standard",
         fetch,
         RailType.SERVICES,

--- a/backend/src/tasterr/runtime_settings.py
+++ b/backend/src/tasterr/runtime_settings.py
@@ -49,7 +49,7 @@ RAIL_TYPE_LABELS: dict[RailType, str] = {
     RailType.RECOMMENDED: "Recommended for you",
     RailType.SERVICES: "Selected services",
     RailType.GENRES: "Genres",
-    RailType.RECENT: "Recently added",
+    RailType.RECENT: "Recent releases",
     RailType.TOP_RATED: "Top rated",
     RailType.DECADES: "By decade",
 }

--- a/backend/tests/test_admin_api.py
+++ b/backend/tests/test_admin_api.py
@@ -122,6 +122,9 @@ def test_admin_settings_default_and_round_trip(tmp_path: Path) -> None:
     assert default.status_code == 200
     assert default.json()["settings"]["region"] == "US"
     assert {item["id"] for item in default.json()["rail_types"]} >= {"hero", "services"}
+    assert {item["id"]: item["label"] for item in default.json()["rail_types"]}["recent"] == (
+        "Recent releases"
+    )
     assert saved.status_code == 200
     assert saved.json()["settings"] == reread.json()["settings"]
     assert reread.json()["settings"]["region"] == "GB"

--- a/backend/tests/test_rails.py
+++ b/backend/tests/test_rails.py
@@ -1,5 +1,6 @@
 """Rail providers and the composer: degrade, de-dupe, drop, paginate (tasks 3.2, 3.3)."""
 
+from datetime import date, timedelta
 from typing import cast
 
 import pytest
@@ -16,11 +17,14 @@ from tasterr.clients.errors import UpstreamUnavailable
 from tasterr.rails.composer import build_extra_rails, build_home
 from tasterr.rails.registry import (
     EXTRA_PAGE_SIZE,
+    GENRE_PICKS,
     HERO_SIZE,
+    HOME_GENRE_COUNT,
     RailContext,
     decade_provider,
     genre_provider,
     home_providers,
+    service_provider,
     top_rated_providers,
 )
 from tasterr.runtime_settings import RailType
@@ -148,6 +152,7 @@ def test_home_provider_ids_and_kinds() -> None:
     providers = home_providers()
     assert [p.id for p in providers] == ["trending", "popular", "recently-added"]
     assert providers[1].kind == "standard"
+    assert providers[2].title == "Recent Releases"
 
 
 async def test_top_region_provider_queries_popular_movies() -> None:
@@ -187,6 +192,30 @@ async def test_decade_provider_bounds_release_window() -> None:
 
 def test_top_rated_provider_ids() -> None:
     assert [p.id for p in top_rated_providers()] == ["top-rated-movie", "top-rated-tv"]
+
+
+async def test_service_provider_queries_recent_flatrate_movies() -> None:
+    service = ServiceOption(
+        provider_id=8,
+        name="Netflix",
+        logo_path=None,
+        display_priority=1,
+    )
+    provider = service_provider(service)
+    fake = FakeCatalog()
+
+    await provider.fetch(_ctx(fake))
+
+    assert provider.title == "Recent Releases on Netflix"
+    assert fake.discover_calls[-1] == {
+        "media": "movie",
+        "sort_by": "primary_release_date.desc",
+        "genres": None,
+        "min_votes": 3,
+        "release_gte": (date.today() - timedelta(days=365)).isoformat(),
+        "release_lte": date.today().isoformat(),
+        "service_ids": [8],
+    }
 
 
 async def test_disabled_provider_is_not_fetched() -> None:
@@ -343,6 +372,51 @@ async def test_extra_rails_paginate_then_complete() -> None:
         pages += 1
         assert pages < 20  # guard against a runaway cursor
     assert pages >= 2  # catalogue spans multiple pages then ends
+
+
+async def test_curated_movie_genres_split_between_home_and_extra() -> None:
+    fake = FakeCatalog()
+    genre_names = (
+        "Western",
+        "Comedy",
+        "Crime",
+        "Drama",
+        "Family",
+        "Fantasy",
+        "History",
+        "Horror",
+        "Music",
+        "Mystery",
+        "Romance",
+        "Science Fiction",
+        "TV Movie",
+        "Thriller",
+        "War",
+        "Adventure",
+        "Documentary",
+    )
+    fake.genre_map_result = {name: index for index, name in enumerate(genre_names, start=1)}
+    present_curated = [name for name in GENRE_PICKS if name in fake.genre_map_result]
+
+    home = await build_home(_ctx(fake))
+    home_genres = [rail.title for rail in home.rails if rail.id.startswith("genre-movie-")]
+
+    extra_genres: list[str] = []
+    cursor: int | None = 0
+    pages = 0
+    while cursor is not None:
+        page = await build_extra_rails(_ctx(fake), cursor)
+        extra_genres.extend(rail.title for rail in page.rails if rail.id.startswith("genre-movie-"))
+        cursor = page.next_cursor
+        pages += 1
+        assert pages < 20  # guard against a runaway cursor
+
+    extra_curated = [name for name in extra_genres if name in GENRE_PICKS]
+    combined = home_genres + extra_curated
+    assert home_genres == present_curated[:HOME_GENRE_COUNT]
+    assert set(home_genres).isdisjoint(extra_curated)
+    assert len(combined) == len(set(combined)) == len(present_curated)
+    assert set(combined) == set(present_curated)
 
 
 async def test_all_disabled_extra_rails_are_terminal_without_catalog_work() -> None:

--- a/openspec/changes/archive/2026-08-19-improve-rail-discovery/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-19-improve-rail-discovery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/archive/2026-08-19-improve-rail-discovery/design.md
+++ b/openspec/changes/archive/2026-08-19-improve-rail-discovery/design.md
@@ -1,0 +1,106 @@
+## Context
+
+See `proposal.md` for motivation and `specs/media-browse/spec.md` for the changed
+behavior contract. TMDB discovery exposes current watch-provider availability and
+release-date filters, but not the date a title joined a provider. The current
+composer also independently derives the four Home genre rails and the additional
+genre catalogue, allowing those two selections to drift.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Derive the Home genre names and the additional-rail exclusion set through one
+  deterministic rule.
+- Describe the release-date data honestly and widen sparse service candidate
+  pools without increasing outbound request count.
+- Pin the corrected behavior with focused regression tests.
+
+**Non-Goals:**
+
+- Guarantee rail fullness or change cross-rail allocation.
+- Add new provider data, endpoints, persistence, configuration, or dependencies.
+
+## Decisions
+
+### Derive the featured genre set from the genres actually used by Home
+
+A shared pure helper will take the ordered curated genre names that exist in the
+movie genre map and return at most `HOME_GENRE_COUNT`. Home will build its genre
+providers from that result, and additional pagination will exclude exactly that
+same result. This fixes the root cause without state shared across requests or
+changes to pagination.
+
+Keeping `set(GENRE_PICKS)` was rejected because it suppresses curated genres that
+Home never consumed. Passing Home response state into the separate pagination
+request was rejected because both endpoints can deterministically derive the
+same answer from the cached genre map.
+
+### Keep the existing service query shape and widen only its release window
+
+The service provider will continue to request one movie page sorted by primary
+release date, filtered to flatrate availability, the selected provider, the
+existing vote floor, and the active region. Only the lower date bound changes
+from 150 to 365 days. This grows small provider pools without additional TMDB
+calls or a new composition policy.
+
+Changing only the sort to popularity was rejected because it does not grow the
+candidate pool and can trade overlap with the release rail for overlap with the
+existing popularity rail. Removing flatrate or vote filters was rejected because
+it changes selected-service semantics or result quality rather than fixing the
+reported defect.
+
+### Preserve stable rail ids while changing user-facing titles
+
+The existing `recently-added` and `service-{provider_id}` ids remain unchanged;
+only titles become `Recent Releases` and `Recent Releases on {service}`. No
+frontend or generated API type change is required because titles are already
+backend-provided strings. The `recent` admin rail-type descriptor becomes
+`Recent releases` so the settings control uses the same honest terminology.
+
+### Deferred and intentionally unchanged behavior
+
+- **Deferred:** mixing TV results into service rails. It adds one discovery call
+  per service and requires an explicit movie/TV merge and ordering policy. Revisit
+  only if the 365-day movie pool remains inadequate in real household use.
+- **Deferred:** fetching page two or guaranteeing a target rail length. It adds
+  outbound work and post-de-duplication limiting complexity. Revisit only with
+  evidence that widened pools still yield objectionably short rails.
+- **Intentionally unchanged:** up to eight selected services continue to filter
+  discovery and recommendations, while only the first four receive Home rails as
+  the existing latency bound.
+- **Intentionally unchanged:** movie-only service results, flatrate filtering,
+  vote floors, selected-service filtering of discovery rails, composition order,
+  cross-rail de-duplication, and the four-item minimum.
+
+## Security considerations
+
+No API endpoint, auth/session path, outbound HTTP client, frontend trust boundary,
+database schema, logging path, or dependency changes. The fixed date window and
+rail titles introduce no user-controlled input. Catalog discovery continues to
+route through `CatalogService` and `clients/`, preserving the outbound-HTTP
+boundary, typed normalization, timeouts, bounded retries, and secret handling.
+Responses retain their existing explicit secret-free models. Therefore none of
+the area-specific endpoint, auth, frontend, database, or dependency checklist
+items in `docs/SECURITY.md` require a code change.
+
+No new dependency is introduced; the existing standard library and project
+modules cover the change.
+
+## Risks / Trade-offs
+
+- [A one-year window can include titles that do not feel brand-new] -> The
+  release-based labels are explicit, newest-first ordering remains, and the wider
+  bound is limited to service rails with demonstrated sparse pools.
+- [Very small providers can still produce short or omitted rails] -> Preserve the
+  existing minimum-size quality floor and defer extra requests until real usage
+  justifies them.
+- [Restored genres lengthen the additional-rail catalogue] -> Existing bounded
+  cursor pagination already handles a larger provider list; regression coverage
+  walks pagination to exhaustion.
+
+## Migration Plan
+
+Deploy the code and synchronized living spec together. There is no data or schema
+migration. Rollback restores the prior labels, 150-day window, and genre
+selection logic without touching persisted state.

--- a/openspec/changes/archive/2026-08-19-improve-rail-discovery/proposal.md
+++ b/openspec/changes/archive/2026-08-19-improve-rail-discovery/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The M2/M5 browse feed can hide eight curated movie genres and presents release-date-based service rails as if TMDB reported when titles joined a service. The service query is also too narrow for several common providers, producing noticeably short rails before normal cross-rail de-duplication.
+
+## What Changes
+
+- Make every curated movie genre reachable by reserving only the genres actually shown on Home and returning the remaining curated genres through infinite scroll.
+- Rename the generic release rail to `Recent Releases`, its admin toggle to `Recent releases`, and per-service rails to `Recent Releases on {service}` so their labels match the data TMDB provides.
+- Expand the per-service recent-release window from 150 to 365 days while preserving the existing movie-only, flatrate, vote-floor, ordering, de-duplication, minimum-size, and four-service-cap behavior.
+- Add regression coverage for complete curated-genre reachability, honest rail titles, and the service discovery query.
+
+This advances the existing M2 media-browse and M5 settings-aware discovery capabilities.
+
+## Non-goals
+
+- Mixing TV shows into service rails.
+- Fetching additional TMDB pages or guaranteeing a fixed number of cards per rail.
+- Expanding the first-four service-rail cap.
+- Removing flatrate filtering, the vote floor, selected-service filtering, cross-rail de-duplication, or the minimum rail size.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `media-browse`: Clarify release-based rail semantics and require all curated movie genres to remain reachable across Home and additional-rail pagination.
+
+## Impact
+
+- Backend rail registration and additional-rail composition under `backend/src/tasterr/rails/`, plus the recent-rail descriptor in runtime settings.
+- Backend rail composer tests and their catalog fake.
+- The `GET /api/v1/home` and `GET /api/v1/rails` response content changes only in rail titles, service candidates, and restored genre rails; the admin settings descriptor for `recent` is relabelled `Recent releases`; response schemas remain unchanged.
+- No new dependencies, database changes, frontend changes, secrets, or new outbound-HTTP boundary are introduced.

--- a/openspec/changes/archive/2026-08-19-improve-rail-discovery/specs/media-browse/spec.md
+++ b/openspec/changes/archive/2026-08-19-improve-rail-discovery/specs/media-browse/spec.md
@@ -1,0 +1,102 @@
+## MODIFIED Requirements
+
+### Requirement: Home feed of a hero and composed rails
+
+`GET /api/v1/home` SHALL return the enabled hero section and an ordered list of
+enabled rails, each a titled list of media summaries. The global runtime snapshot
+SHALL gate registered provider types before they fetch. The provider set SHALL
+include non-personalized trending, popular-in-region, recent-release, genre, and
+bounded per-selected-service rails plus the authenticated user's
+recommended-for-you, because-you-watched, and my-list providers. The generic
+release rail SHALL be titled `Recent Releases`. Each per-selected-service rail
+SHALL use current flatrate movie availability and movie release dates from the
+preceding 365 days and SHALL be titled `Recent Releases on {service}`. Dynamic
+genre and service instances share their registered type gate; absent disablement
+means enabled, including for a newly registered type. A provider failure SHALL
+degrade the feed to fewer rails rather than fail the request, and rails with
+fewer than a minimum number of items SHALL be omitted. Titles SHALL be
+de-duplicated across returned rails so a title does not repeat later. Disabling
+every provider SHALL return a valid empty feed rather than override the admin's
+choice.
+
+#### Scenario: Authenticated home returns enabled hero and rails
+- **WHEN** an authenticated client requests `GET /api/v1/home` with default
+  settings
+- **THEN** it receives a hero and an ordered set of non-empty rails
+
+#### Scenario: Disabled type is neither fetched nor returned
+- **WHEN** an admin has disabled a registered hero or rail type
+- **THEN** that section/provider performs no catalog work and is absent from the
+  feed
+
+#### Scenario: New provider type defaults enabled
+- **WHEN** a registered type has no entry in the disabled set
+- **THEN** it participates in composition by default
+
+#### Scenario: Generic release rail is labelled honestly
+- **WHEN** the generic release provider yields enough movie titles
+- **THEN** the home feed includes a `Recent Releases` rail
+
+#### Scenario: Selected service produces a bounded service rail
+- **WHEN** a selected service has provider metadata and enough flatrate movie
+  titles released during the preceding 365 days
+- **THEN** the home feed includes a `Recent Releases on {service}` rail for it,
+  up to the documented service-rail cap
+
+#### Scenario: Service metadata failure degrades independently
+- **WHEN** provider metadata cannot be resolved and no stale value exists
+- **THEN** service rails are omitted while other home providers still compose
+
+#### Scenario: One failing provider still returns the rest
+- **WHEN** a single rail provider errors while composing the home feed
+- **THEN** the response still contains the enabled hero and remaining rails
+
+#### Scenario: Under-filled rail omitted
+- **WHEN** a provider yields fewer than the minimum number of items
+- **THEN** that rail is omitted from the feed
+
+#### Scenario: Titles de-duplicated across rails
+- **WHEN** a title qualifies for more than one rail in a single response
+- **THEN** it appears in only one of the returned rails
+
+#### Scenario: Home is personalized per user
+- **WHEN** two users with different taste profiles request `GET /api/v1/home`
+- **THEN** each receives enabled personalized rails reflecting their own profile
+
+#### Scenario: Signal-less user sees the non-personalized home
+- **WHEN** a user with no signals requests the home feed
+- **THEN** the response contains enabled non-personalized rails and no
+  personalized rail placeholders
+
+#### Scenario: Every section disabled returns a valid empty feed
+- **WHEN** the admin disables hero and every registered rail type
+- **THEN** the endpoint returns 200 with an empty hero/rail result
+
+### Requirement: Infinite-scroll additional rails
+
+`GET /api/v1/rails?cursor=` SHALL return a page of enabled additional rails
+(top-rated, by-decade, and further genres across movie and TV) together with a
+cursor for the next page or a signal that the bounded catalogue is exhausted.
+Every available curated movie genre not selected for the Home feed SHALL remain
+reachable through these additional pages. The provider catalogue SHALL be
+filtered by the request's global rail-type gates before slicing and SHALL use the
+same active region/service discovery context as home, so a cursor is stable for
+that settings snapshot.
+
+#### Scenario: First page returns enabled rails and a next cursor
+- **WHEN** a client requests `GET /api/v1/rails` with no cursor
+- **THEN** it receives a page of enabled settings-aware rails and a cursor for the
+  next page
+
+#### Scenario: Remaining curated movie genres stay reachable
+- **WHEN** more curated movie genres are available than the Home feed displays
+- **THEN** every remaining curated movie genre occurs in the additional-rail
+  catalogue
+
+#### Scenario: Disabled additional type is skipped before pagination
+- **WHEN** top-rated, decade, or genre rails are disabled
+- **THEN** providers of that type are not fetched and do not consume a page slot
+
+#### Scenario: Exhausted catalogue signals completion
+- **WHEN** a client pages past the last enabled available rail
+- **THEN** the response contains no further rails and signals that paging is done

--- a/openspec/changes/archive/2026-08-19-improve-rail-discovery/tasks.md
+++ b/openspec/changes/archive/2026-08-19-improve-rail-discovery/tasks.md
@@ -1,0 +1,9 @@
+## 1. Rail Behavior
+
+- [x] 1.1 Rename release-based rail and admin labels, widen the service release window to 365 days, and extend provider tests to verify the labels and exact discovery parameters
+- [x] 1.2 Derive Home and additional genre selections from one shared ordered rule, and add a pagination regression proving every available curated movie genre is reachable exactly once across those catalogues
+
+## 2. Verification
+
+- [x] 2.1 Run the focused rail tests and strict OpenSpec validation, fixing any failures
+- [x] 2.2 Run `just check` in the devcontainer and fix any failures

--- a/openspec/specs/media-browse/spec.md
+++ b/openspec/specs/media-browse/spec.md
@@ -2,21 +2,27 @@
 
 ## Purpose
 TBD - created by archiving change m2-browse. Update Purpose after archive.
+
 ## Requirements
+
 ### Requirement: Home feed of a hero and composed rails
 
 `GET /api/v1/home` SHALL return the enabled hero section and an ordered list of
 enabled rails, each a titled list of media summaries. The global runtime snapshot
 SHALL gate registered provider types before they fetch. The provider set SHALL
-include non-personalized trending, popular-in-region, recently-added, genre, and
+include non-personalized trending, popular-in-region, recent-release, genre, and
 bounded per-selected-service rails plus the authenticated user's
-recommended-for-you, because-you-watched, and my-list providers. Dynamic genre
-and service instances share their registered type gate; absent disablement means
-enabled, including for a newly registered type. A provider failure SHALL degrade
-the feed to fewer rails rather than fail the request, and rails with fewer than a
-minimum number of items SHALL be omitted. Titles SHALL be de-duplicated across
-returned rails so a title does not repeat later. Disabling every provider SHALL
-return a valid empty feed rather than override the admin's choice.
+recommended-for-you, because-you-watched, and my-list providers. The generic
+release rail SHALL be titled `Recent Releases`. Each per-selected-service rail
+SHALL use current flatrate movie availability and movie release dates from the
+preceding 365 days and SHALL be titled `Recent Releases on {service}`. Dynamic
+genre and service instances share their registered type gate; absent disablement
+means enabled, including for a newly registered type. A provider failure SHALL
+degrade the feed to fewer rails rather than fail the request, and rails with
+fewer than a minimum number of items SHALL be omitted. Titles SHALL be
+de-duplicated across returned rails so a title does not repeat later. Disabling
+every provider SHALL return a valid empty feed rather than override the admin's
+choice.
 
 #### Scenario: Authenticated home returns enabled hero and rails
 - **WHEN** an authenticated client requests `GET /api/v1/home` with default
@@ -32,10 +38,15 @@ return a valid empty feed rather than override the admin's choice.
 - **WHEN** a registered type has no entry in the disabled set
 - **THEN** it participates in composition by default
 
+#### Scenario: Generic release rail is labelled honestly
+- **WHEN** the generic release provider yields enough movie titles
+- **THEN** the home feed includes a `Recent Releases` rail
+
 #### Scenario: Selected service produces a bounded service rail
-- **WHEN** a selected service has provider metadata and enough catalog titles
-- **THEN** the home feed includes a `New on {service}` rail for it, up to the
-  documented service-rail cap
+- **WHEN** a selected service has provider metadata and enough flatrate movie
+  titles released during the preceding 365 days
+- **THEN** the home feed includes a `Recent Releases on {service}` rail for it,
+  up to the documented service-rail cap
 
 #### Scenario: Service metadata failure degrades independently
 - **WHEN** provider metadata cannot be resolved and no stale value exists
@@ -71,14 +82,21 @@ return a valid empty feed rather than override the admin's choice.
 `GET /api/v1/rails?cursor=` SHALL return a page of enabled additional rails
 (top-rated, by-decade, and further genres across movie and TV) together with a
 cursor for the next page or a signal that the bounded catalogue is exhausted.
-The provider catalogue SHALL be filtered by the request's global rail-type gates
-before slicing and SHALL use the same active region/service discovery context as
-home, so a cursor is stable for that settings snapshot.
+Every available curated movie genre not selected for the Home feed SHALL remain
+reachable through these additional pages. The provider catalogue SHALL be
+filtered by the request's global rail-type gates before slicing and SHALL use the
+same active region/service discovery context as home, so a cursor is stable for
+that settings snapshot.
 
 #### Scenario: First page returns enabled rails and a next cursor
 - **WHEN** a client requests `GET /api/v1/rails` with no cursor
 - **THEN** it receives a page of enabled settings-aware rails and a cursor for the
   next page
+
+#### Scenario: Remaining curated movie genres stay reachable
+- **WHEN** more curated movie genres are available than the Home feed displays
+- **THEN** every remaining curated movie genre occurs in the additional-rail
+  catalogue
 
 #### Scenario: Disabled additional type is skipped before pagination
 - **WHEN** top-rated, decade, or genre rails are disabled
@@ -366,4 +384,3 @@ browsing context without granting the destination access to the opener.
 
 - **WHEN** the user activates the TMDB link in a detail view
 - **THEN** it opens in a separate browsing context with opener access disabled
-


### PR DESCRIPTION
## What / why

Restores all curated movie genre rails by excluding only genres actually selected for Home from paginated discovery. Renames release-based rails and the admin toggle to honest “Recent Releases” language, and widens the selected-service movie window to 365 days so sparse service rails have a larger candidate pool. Adds regression coverage for missing genre entries, pagination uniqueness, service query parameters, and the admin label.

## Spec

- OpenSpec change: `improve-rail-discovery`
- [x] Change archived on this branch (if applicable)

## Checklist

- [x] `just check` passes locally
- [x] Title is the Conventional Commit subject for the squash