### PR TITLE
feat: add Plex playback links and taste onboarding

### DIFF
--- a/backend/src/tasterr/api/onboarding.py
+++ b/backend/src/tasterr/api/onboarding.py
@@ -1,0 +1,77 @@
+"""Optional cold-start taste picker state and completion.
+
+Only users with no signals are invited. Completion records ordinary watchlist
+signals and a per-user seen bit; no selected title is returned or logged.
+"""
+
+from typing import Annotated, Literal, cast
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tasterr.api.runtime_settings import RuntimeSettingsDep
+from tasterr.api.taste import refresh_profile
+from tasterr.auth.deps import AuthedSession, get_db, require_same_origin, require_session
+from tasterr.auth.ratelimit import mutation_rate_limit
+from tasterr.recommend import store
+from tasterr.recommend.signals import MAX_TMDB_ID, MediaType
+from tasterr.settings import Settings, get_settings
+
+router = APIRouter()
+
+
+class TasteOnboardingStateResponse(BaseModel):
+    state: Literal["pending", "show", "done"]
+
+
+class TasteOnboardingSelection(BaseModel):
+    media_type: MediaType
+    tmdb_id: int = Field(ge=1, le=MAX_TMDB_ID)
+
+
+class TasteOnboardingBody(BaseModel):
+    selections: Annotated[list[TasteOnboardingSelection], Field(max_length=12)] = []
+
+
+class TasteOnboardingSubmitResponse(BaseModel):
+    recorded_signals: int
+
+
+@router.get("/taste-onboarding", response_model=TasteOnboardingStateResponse)
+async def get_taste_onboarding(
+    authed: Annotated[AuthedSession, Depends(require_session)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    request: Request,
+) -> TasteOnboardingStateResponse:
+    if authed.user.taste_onboarding_seen or await store.has_signals(db, authed.user.id):
+        return TasteOnboardingStateResponse(state="done")
+    seeding = cast("set[int]", request.app.state.seeding)
+    return TasteOnboardingStateResponse(state="pending" if authed.user.id in seeding else "show")
+
+
+@router.post(
+    "/taste-onboarding",
+    response_model=TasteOnboardingSubmitResponse,
+    dependencies=[Depends(require_same_origin), Depends(mutation_rate_limit)],
+)
+async def complete_taste_onboarding(
+    payload: TasteOnboardingBody,
+    authed: Annotated[AuthedSession, Depends(require_session)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    request: Request,
+    settings: Annotated[Settings, Depends(get_settings)],
+    runtime: RuntimeSettingsDep,
+) -> TasteOnboardingSubmitResponse:
+    unique: set[tuple[MediaType, int]] = {
+        (item.media_type, item.tmdb_id) for item in payload.selections
+    }
+    recorded = 0
+    for media_type, tmdb_id in unique:
+        if await store.record_signal(db, authed.user.id, media_type, tmdb_id, "watchlist"):
+            recorded += 1
+    authed.user.taste_onboarding_seen = True
+    await db.commit()
+    if unique:
+        await refresh_profile(request, settings, db, authed.user.id, runtime)
+    return TasteOnboardingSubmitResponse(recorded_signals=recorded)

--- a/backend/src/tasterr/api/request.py
+++ b/backend/src/tasterr/api/request.py
@@ -26,6 +26,7 @@ from tasterr.catalog.availability import Availability, availability_from_code
 from tasterr.clients.errors import UpstreamRejected, UpstreamUnavailable
 from tasterr.clients.seerr import MediaType, SeerrAuthClient, SeerrClient
 from tasterr.recommend import store
+from tasterr.recommend.signals import MAX_TMDB_ID
 from tasterr.runtime_settings import RuntimeSettings
 from tasterr.settings import Settings, get_settings
 
@@ -37,7 +38,7 @@ RequestStatus = Literal["ok", "re_auth_required", "unavailable", "failed"]
 
 class RequestBody(BaseModel):
     media_type: Literal["movie", "tv"]
-    tmdb_id: int = Field(ge=1)
+    tmdb_id: int = Field(ge=1, le=MAX_TMDB_ID)
 
 
 class RequestResponse(BaseModel):

--- a/backend/src/tasterr/api/signals.py
+++ b/backend/src/tasterr/api/signals.py
@@ -18,7 +18,7 @@ from tasterr.api.taste import refresh_profile
 from tasterr.auth.deps import AuthedSession, get_db, require_same_origin, require_session
 from tasterr.auth.ratelimit import mutation_rate_limit
 from tasterr.recommend import store
-from tasterr.recommend.signals import TOGGLE_KINDS, ClientSignalKind, MediaType
+from tasterr.recommend.signals import MAX_TMDB_ID, TOGGLE_KINDS, ClientSignalKind, MediaType
 from tasterr.settings import Settings, get_settings
 
 router = APIRouter()
@@ -26,7 +26,7 @@ router = APIRouter()
 
 class SignalBody(BaseModel):
     media_type: MediaType
-    tmdb_id: int = Field(ge=1)
+    tmdb_id: int = Field(ge=1, le=MAX_TMDB_ID)
     kind: ClientSignalKind
     retract: bool = False
 

--- a/backend/src/tasterr/api/taste.py
+++ b/backend/src/tasterr/api/taste.py
@@ -18,7 +18,7 @@ from tasterr.catalog.service import CatalogService
 from tasterr.clients.seerr import SeerrClient
 from tasterr.clients.tmdb import TmdbClient
 from tasterr.db.runtime_settings import load_runtime_settings
-from tasterr.recommend.seed import seed_in_background
+from tasterr.recommend.seed import reserve_seed, seed_in_background
 from tasterr.recommend.service import TasteService
 from tasterr.runtime_settings import RuntimeSettings
 from tasterr.settings import Settings
@@ -108,17 +108,34 @@ def schedule_seed(request: Request, settings: Settings, user_id: int, seerr_user
 
     maker = cast("async_sessionmaker[AsyncSession]", state.sessionmaker)
     seeding = cast("set[int]", state.seeding)
+    if not reserve_seed(seeding, user_id):
+        return
 
     async def run_seed() -> None:
-        async with maker() as db:
-            runtime = await load_runtime_settings(db)
+        try:
+            async with maker() as db:
+                runtime = await load_runtime_settings(db)
 
-        def factory(seed_db: AsyncSession) -> TasteService:
-            return taste_factory(seed_db, runtime)
+            def factory(seed_db: AsyncSession) -> TasteService:
+                return taste_factory(seed_db, runtime)
 
-        await seed_in_background(maker, factory, seerr, seeding, user_id, seerr_user_id)
+            await seed_in_background(
+                maker,
+                factory,
+                seerr,
+                seeding,
+                user_id,
+                seerr_user_id,
+                reserved=True,
+            )
+        finally:
+            seeding.discard(user_id)
 
-    task = asyncio.create_task(run_seed())
+    try:
+        task = asyncio.create_task(run_seed())
+    except Exception:
+        seeding.discard(user_id)
+        raise
     tasks = cast("set[asyncio.Task[None]]", state.seed_tasks)
     tasks.add(task)
     task.add_done_callback(tasks.discard)

--- a/backend/src/tasterr/catalog/availability.py
+++ b/backend/src/tasterr/catalog/availability.py
@@ -9,6 +9,7 @@ Seerr errors degrade to Unknown in the service layer — never a stale value (SP
 import asyncio
 from collections.abc import Iterable
 from typing import Literal
+from urllib.parse import parse_qsl, quote, urlsplit
 
 from pydantic import BaseModel
 
@@ -28,11 +29,24 @@ _CODE_TO_STATUS: dict[int, AvailabilityStatus] = {
     4: "partial",
     5: "available",
 }
+# Partial means some seasons are present and Plex can still play the title.
+_PLAYABLE_CODES = frozenset({4, 5})
 
 # Short TTL so a fresh request reflects in badges quickly; stale=0 so a failed
 # refresh never serves a stale status — the service degrades it to Unknown.
 AVAIL_OPTS = CacheOpts(ttl=60, stale=0)
 _BATCH_CONCURRENCY = 8
+
+
+class PlaybackVariant(BaseModel):
+    web_url: str
+    app_url: str | None = None
+    android_intent_url: str | None = None
+
+
+class PlaybackLinks(BaseModel):
+    regular: PlaybackVariant | None = None
+    four_k: PlaybackVariant | None = None
 
 
 class Availability(BaseModel):
@@ -41,6 +55,7 @@ class Availability(BaseModel):
 
     status: AvailabilityStatus
     known: bool
+    playback: PlaybackLinks | None = None
 
 
 UNKNOWN = Availability(status="unknown", known=False)
@@ -58,7 +73,94 @@ def to_availability(media_info: SeerrMediaInfo | None) -> Availability:
     """Map Seerr's `mediaInfo` (or its absence) to a known Availability."""
     if media_info is None:
         return NOT_REQUESTED
-    return availability_from_code(media_info.status)
+    codes = [code for code in (media_info.status, media_info.status_4k) if code in _CODE_TO_STATUS]
+    availability = availability_from_code(max(codes, default=0))
+    regular = (
+        _playback_variant(media_info.web_url, media_info.app_url)
+        if media_info.status in _PLAYABLE_CODES
+        else None
+    )
+    four_k = (
+        _playback_variant(media_info.web_url_4k, media_info.app_url_4k)
+        if media_info.status_4k in _PLAYABLE_CODES
+        else None
+    )
+    playback = PlaybackLinks(regular=regular, four_k=four_k) if regular or four_k else None
+    return availability.model_copy(update={"playback": playback})
+
+
+def _playback_variant(web_url: str | None, app_url: str | None) -> PlaybackVariant | None:
+    safe_web = _safe_web_url(web_url)
+    if safe_web is None:
+        return None
+    safe_app = _safe_app_url(app_url)
+    android = _android_intent_url(safe_app, safe_web) if safe_app is not None else None
+    return PlaybackVariant(web_url=safe_web, app_url=safe_app, android_intent_url=android)
+
+
+def _safe_web_url(value: str | None) -> str | None:
+    if value is None or _has_unsafe_chars(value):
+        return None
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError:
+        return None
+    if (
+        parsed.scheme.lower() != "https"
+        or parsed.hostname is None
+        or parsed.hostname.lower() != "app.plex.tv"
+        or parsed.username is not None
+        or parsed.password is not None
+        or port not in (None, 443)
+        or _has_plex_token_parameter(parsed.query)
+        or _has_plex_token_parameter(parsed.fragment.split("?", 1)[-1])
+    ):
+        return None
+    return value
+
+
+def _safe_app_url(value: str | None) -> str | None:
+    if value is None or "#" in value or _has_unsafe_chars(value):
+        return None
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError:
+        return None
+    if (
+        parsed.scheme.lower() != "plex"
+        or parsed.hostname is None
+        or parsed.hostname.lower() != "preplay"
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+        or parsed.path not in ("", "/")
+        or not parsed.query
+        or parsed.fragment
+        or _has_plex_token_parameter(parsed.query)
+    ):
+        return None
+    return value
+
+
+def _android_intent_url(app_url: str, web_url: str) -> str:
+    target = app_url.split("://", 1)[1]
+    fallback = quote(web_url, safe="")
+    return (
+        f"intent://{target}#Intent;scheme=plex;package=com.plexapp.android;"
+        f"S.browser_fallback_url={fallback};end"
+    )
+
+
+def _has_unsafe_chars(value: str) -> bool:
+    return value.strip() != value or any(ord(char) < 32 or ord(char) == 127 for char in value)
+
+
+def _has_plex_token_parameter(value: str) -> bool:
+    return any(
+        name.casefold() == "x-plex-token" for name, _ in parse_qsl(value, keep_blank_values=True)
+    )
 
 
 class AvailabilityService:

--- a/backend/src/tasterr/clients/seerr.py
+++ b/backend/src/tasterr/clients/seerr.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime
 from typing import Literal
 
 import httpx
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 from tasterr.clients.errors import UpstreamRejected, UpstreamUnavailable
 
@@ -93,10 +93,17 @@ class SeerrMediaInfo(BaseModel):
     3 processing, 4 partially available, 5 available); `seasons` carries per-season
     status for TV. catalog/availability.py maps this to the domain model."""
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     status: int = 0
+    status_4k: int = Field(default=0, alias="status4k")
     seasons: list[SeerrSeasonStatus] = []
+    web_url: str | None = Field(default=None, validation_alias=AliasChoices("plexUrl", "mediaUrl"))
+    app_url: str | None = Field(default=None, alias="iOSPlexUrl")
+    web_url_4k: str | None = Field(
+        default=None, validation_alias=AliasChoices("plexUrl4k", "mediaUrl4k")
+    )
+    app_url_4k: str | None = Field(default=None, alias="iOSPlexUrl4k")
 
 
 class _SeerrTitle(BaseModel):

--- a/backend/src/tasterr/db/alembic/versions/0005_taste_onboarding.py
+++ b/backend/src/tasterr/db/alembic/versions/0005_taste_onboarding.py
@@ -1,0 +1,33 @@
+"""Remember completion of the optional taste onboarding picker.
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-08-20
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0005"
+down_revision: str | None = "0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "taste_onboarding_seen",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "taste_onboarding_seen")

--- a/backend/src/tasterr/db/models.py
+++ b/backend/src/tasterr/db/models.py
@@ -24,6 +24,7 @@ class User(Base):
     avatar_url: Mapped[str | None]
     auth_type: Mapped[str] = mapped_column(String(8))  # 'plex' | 'local'
     is_admin: Mapped[bool] = mapped_column(default=False)
+    taste_onboarding_seen: Mapped[bool] = mapped_column(default=False, server_default=text("0"))
     created_at: Mapped[datetime] = mapped_column(DateTime(), default=utcnow)
     last_login_at: Mapped[datetime] = mapped_column(DateTime(), default=utcnow)
 

--- a/backend/src/tasterr/main.py
+++ b/backend/src/tasterr/main.py
@@ -16,6 +16,7 @@ from tasterr.api.auth import router as auth_router
 from tasterr.api.availability import router as availability_router
 from tasterr.api.home import router as home_router
 from tasterr.api.meta import router as meta_router
+from tasterr.api.onboarding import router as onboarding_router
 from tasterr.api.recommendations import router as recommendations_router
 from tasterr.api.request import router as request_router
 from tasterr.api.search import router as search_router
@@ -96,6 +97,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(availability_router, prefix="/api/v1")
     app.include_router(request_router, prefix="/api/v1")
     app.include_router(signals_router, prefix="/api/v1")
+    app.include_router(onboarding_router, prefix="/api/v1")
     app.include_router(recommendations_router, prefix="/api/v1")
     app.state.pin_store = PinStore()
     # Tight login bucket (SPEC §9): 10 attempts per client IP, refilling 10/min.

--- a/backend/src/tasterr/recommend/seed.py
+++ b/backend/src/tasterr/recommend/seed.py
@@ -19,6 +19,14 @@ from tasterr.recommend.service import TasteService
 logger = logging.getLogger("tasterr.seed")
 
 
+def reserve_seed(seeding: set[int], user_id: int) -> bool:
+    """Synchronously reserve one user's background seed before scheduling it."""
+    if user_id in seeding:
+        return False
+    seeding.add(user_id)
+    return True
+
+
 async def seed_user(
     db: AsyncSession,
     taste: TasteService,
@@ -57,14 +65,15 @@ async def seed_in_background(
     seeding: set[int],
     user_id: int,
     seerr_user_id: int,
+    *,
+    reserved: bool = False,
 ) -> None:
     """The post-login runner: opens its own session (the request's is gone by
     the time this runs), seeds only a signal-less user, single-flights per
     user (in-process set — one replica by design), and swallows every failure
     with a log line carrying no viewing behavior."""
-    if user_id in seeding:
+    if not reserved and not reserve_seed(seeding, user_id):
         return
-    seeding.add(user_id)
     try:
         async with maker() as db:
             if await store.has_signals(db, user_id):

--- a/backend/src/tasterr/recommend/signals.py
+++ b/backend/src/tasterr/recommend/signals.py
@@ -10,6 +10,7 @@ from typing import Literal, get_args
 
 MediaType = Literal["movie", "tv"]
 TitleKey = tuple[MediaType, int]
+MAX_TMDB_ID = 2_147_483_647
 
 SignalKind = Literal[
     "request", "watchlist", "detail_open", "not_interested", "seed_request_history"

--- a/backend/tests/live/test_seerr_live.py
+++ b/backend/tests/live/test_seerr_live.py
@@ -43,7 +43,7 @@ import httpx
 import pytest
 from pydantic import BaseModel, ConfigDict, Field
 
-from tasterr.catalog.availability import NOT_REQUESTED, to_availability
+from tasterr.catalog.availability import to_availability
 from tasterr.clients.errors import UpstreamRejected
 from tasterr.clients.seerr import SeerrAuthClient, SeerrClient
 
@@ -212,19 +212,25 @@ async def test_availability_read_smoke_and_not_in_library() -> None:
             assert isinstance(info.status, int)
 
         unrequested = await client.media_status("movie", int(REQUEST_TMDB_ID))
-        assert to_availability(unrequested) == NOT_REQUESTED
+        availability = to_availability(unrequested)
+        assert availability.status == "not_requested"
+        assert availability.known
 
 
 @requires_available
 async def test_available_title_has_a_media_record() -> None:
-    """Proves the available-title contract: an operator-supplied in-library id
-    returns a real `mediaInfo` whose MediaStatus maps to available."""
+    """Proves the playback-link contract when the operator supplies a Plex-backed
+    in-library title; other media-server backends skip without exposing links."""
     tmdb_id = int(AVAILABLE_TMDB_ID)
     async with httpx.AsyncClient(timeout=10.0) as http:
         info = await SeerrClient(http, URL, API_KEY).media_status("movie", tmdb_id)
 
         assert info is not None, "expected a media record for the supplied available id"
-        assert to_availability(info).status == "available"
+        availability = to_availability(info)
+        assert availability.status in ("partial", "available")
+        if availability.playback is None:
+            pytest.skip("available title has no Plex playback links")
+        assert availability.playback.regular is not None or availability.playback.four_k is not None
 
 
 @requires_history
@@ -300,7 +306,9 @@ async def test_request_as_user_attribution_and_cleanup() -> None:
     async with httpx.AsyncClient(timeout=10.0) as http:
         login = await SeerrAuthClient(http, URL).login_local(EMAIL, PASSWORD)
         info = await SeerrClient(http, URL, API_KEY).media_status("movie", tmdb_id)
-        assert to_availability(info) == NOT_REQUESTED
+        availability = to_availability(info)
+        assert availability.status == "not_requested"
+        assert availability.known
 
         created_may_have_succeeded = False
         request_id: int | None = None

--- a/backend/tests/test_api_taste.py
+++ b/backend/tests/test_api_taste.py
@@ -50,7 +50,10 @@ async def test_background_seed_resolves_its_own_runtime_snapshot(
         seeding: set[int],
         user_id: int,
         seerr_user_id: int,
+        *,
+        reserved: bool = False,
     ) -> None:
+        assert reserved is True
         async with seed_maker() as db:
             factory(db)
 
@@ -62,7 +65,8 @@ async def test_background_seed_resolves_its_own_runtime_snapshot(
     app.state.http = http
     app.state.catalog_cache = Cache()
     app.state.sessionmaker = maker
-    app.state.seeding = set()
+    seeding: set[int] = set()
+    app.state.seeding = seeding
     seed_tasks: set[asyncio.Task[None]] = set()
     app.state.seed_tasks = seed_tasks
     scope = cast(
@@ -89,9 +93,12 @@ async def test_background_seed_resolves_its_own_runtime_snapshot(
     )
 
     schedule_seed(request, settings, user_id=1, seerr_user_id=7)
+    assert seeding == {1}
+    schedule_seed(request, settings, user_id=1, seerr_user_id=7)
     tasks = list(seed_tasks)
     await asyncio.gather(*tasks)
 
     assert captured == [("GB", (8, 337))]
+    assert seeding == set()
     await http.aclose()
     await engine.dispose()

--- a/backend/tests/test_availability_api.py
+++ b/backend/tests/test_availability_api.py
@@ -89,7 +89,16 @@ def test_availability_requires_a_session(tmp_path: Path) -> None:
 def test_batch_returns_a_status_per_title(tmp_path: Path) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path == "/api/v1/movie/1":
-            return httpx.Response(200, json={"mediaInfo": {"status": 5}})
+            return httpx.Response(
+                200,
+                json={
+                    "mediaInfo": {
+                        "status": 5,
+                        "mediaUrl": "https://app.plex.tv/desktop/#!/details",
+                        "iOSPlexUrl": "plex://preplay/?metadataKey=x",
+                    }
+                },
+            )
         return httpx.Response(404, json={})  # movie/2: known, not in library
 
     app = _app(tmp_path)
@@ -103,8 +112,23 @@ def test_batch_returns_a_status_per_title(tmp_path: Path) -> None:
 
     assert response.status_code == 200
     assert response.json() == {
-        "movie:1": {"status": "available", "known": True},
-        "movie:2": {"status": "not_requested", "known": True},
+        "movie:1": {
+            "status": "available",
+            "known": True,
+            "playback": {
+                "regular": {
+                    "web_url": "https://app.plex.tv/desktop/#!/details",
+                    "app_url": "plex://preplay/?metadataKey=x",
+                    "android_intent_url": (
+                        "intent://preplay/?metadataKey=x#Intent;scheme=plex;"
+                        "package=com.plexapp.android;S.browser_fallback_url="
+                        "https%3A%2F%2Fapp.plex.tv%2Fdesktop%2F%23%21%2Fdetails;end"
+                    ),
+                },
+                "four_k": None,
+            },
+        },
+        "movie:2": {"status": "not_requested", "known": True, "playback": None},
     }
 
 
@@ -125,8 +149,8 @@ def test_one_unresolved_title_does_not_fail_the_batch(tmp_path: Path) -> None:
 
     assert response.status_code == 200
     body = response.json()
-    assert body["movie:1"] == {"status": "available", "known": True}
-    assert body["movie:3"] == {"status": "unknown", "known": False}
+    assert body["movie:1"] == {"status": "available", "known": True, "playback": None}
+    assert body["movie:3"] == {"status": "unknown", "known": False, "playback": None}
 
 
 def test_unconfigured_seerr_yields_unknown_without_a_call(tmp_path: Path) -> None:
@@ -142,8 +166,8 @@ def test_unconfigured_seerr_yields_unknown_without_a_call(tmp_path: Path) -> Non
 
     assert response.status_code == 200
     assert response.json() == {
-        "movie:1": {"status": "unknown", "known": False},
-        "tv:2": {"status": "unknown", "known": False},
+        "movie:1": {"status": "unknown", "known": False, "playback": None},
+        "tv:2": {"status": "unknown", "known": False, "playback": None},
     }
 
 

--- a/backend/tests/test_browse_api.py
+++ b/backend/tests/test_browse_api.py
@@ -280,13 +280,31 @@ def _override_availability(
 def test_title_detail_includes_availability(tmp_path: Path) -> None:
     app = _app(tmp_path)
     app.dependency_overrides[get_catalog] = lambda: cast("CatalogService", FakeCatalog())
-    _override_availability(app, lambda _: httpx.Response(200, json={"mediaInfo": {"status": 5}}))
+    _override_availability(
+        app,
+        lambda _: httpx.Response(
+            200,
+            json={
+                "mediaInfo": {
+                    "status": 5,
+                    "plexUrl": "https://app.plex.tv/desktop/#!/details",
+                    "iOSPlexUrl": "plex://preplay/?metadataKey=x",
+                }
+            },
+        ),
+    )
     db_path = tmp_path / "tasterr.db"
     with _authed_client(app, db_path) as client:
         response = client.get("/api/v1/title/movie/42")
 
     assert response.status_code == 200
-    assert response.json()["availability"] == {"status": "available", "known": True}
+    availability = response.json()["availability"]
+    assert availability["status"] == "available"
+    assert availability["known"] is True
+    assert availability["playback"]["regular"]["web_url"] == (
+        "https://app.plex.tv/desktop/#!/details"
+    )
+    assert availability["playback"]["regular"]["android_intent_url"].startswith("intent://preplay/")
 
 
 def test_title_availability_degrades_when_seerr_down(tmp_path: Path) -> None:
@@ -301,7 +319,7 @@ def test_title_availability_degrades_when_seerr_down(tmp_path: Path) -> None:
     assert response.status_code == 200
     body = response.json()
     assert body["id"] == 42
-    assert body["availability"] == {"status": "unknown", "known": False}
+    assert body["availability"] == {"status": "unknown", "known": False, "playback": None}
 
 
 # ── Search (4.3) ─────────────────────────────────────────────────────────────

--- a/backend/tests/test_catalog_availability.py
+++ b/backend/tests/test_catalog_availability.py
@@ -10,6 +10,8 @@ from tasterr.catalog.availability import (
     UNKNOWN,
     Availability,
     AvailabilityService,
+    PlaybackLinks,
+    PlaybackVariant,
     availability_from_code,
     to_availability,
 )
@@ -43,6 +45,183 @@ def test_absent_media_info_is_not_requested() -> None:
 
 def test_media_info_maps_to_status() -> None:
     assert to_availability(SeerrMediaInfo(status=5)) == Availability(status="available", known=True)
+
+
+def test_available_overseerr_links_are_validated_and_build_android_fallback() -> None:
+    web = "https://app.plex.tv/desktop/#!/server/test/details?key=%2Flibrary%2F42"
+    app = "plex://preplay/?metadataKey=%2Flibrary%2Fmetadata%2F42&server=test"
+
+    result = to_availability(
+        SeerrMediaInfo.model_validate({"status": 5, "plexUrl": web, "iOSPlexUrl": app})
+    )
+
+    assert result.playback == PlaybackLinks(
+        regular=PlaybackVariant(
+            web_url=web,
+            app_url=app,
+            android_intent_url=(
+                "intent://preplay/?metadataKey=%2Flibrary%2Fmetadata%2F42&server=test"
+                "#Intent;scheme=plex;package=com.plexapp.android;"
+                "S.browser_fallback_url=https%3A%2F%2Fapp.plex.tv%2Fdesktop%2F%23%21%2F"
+                "server%2Ftest%2Fdetails%3Fkey%3D%252Flibrary%252F42;end"
+            ),
+        )
+    )
+
+
+def test_partially_available_regular_links_are_preserved() -> None:
+    result = to_availability(
+        SeerrMediaInfo.model_validate(
+            {
+                "status": 4,
+                "plexUrl": "https://app.plex.tv/desktop#!/partial",
+                "iOSPlexUrl": "plex://preplay/?metadataKey=partial",
+            }
+        )
+    )
+
+    assert result.status == "partial"
+    assert result.playback is not None
+    assert result.playback.regular is not None
+    assert result.playback.regular.web_url == "https://app.plex.tv/desktop#!/partial"
+
+
+def test_partially_available_4k_links_are_preserved() -> None:
+    result = to_availability(
+        SeerrMediaInfo.model_validate(
+            {
+                "status": 1,
+                "status4k": 4,
+                "mediaUrl4k": "https://app.plex.tv/desktop#!/partial-4k",
+                "iOSPlexUrl4k": "plex://preplay/?metadataKey=partial-4k",
+            }
+        )
+    )
+
+    assert result.status == "partial"
+    assert result.playback is not None
+    assert result.playback.four_k is not None
+    assert result.playback.four_k.web_url == "https://app.plex.tv/desktop#!/partial-4k"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"status": 4},
+        {
+            "status": 4,
+            "plexUrl": "https://evil.example/partial",
+            "iOSPlexUrl": "plex://preplay/?metadataKey=partial",
+        },
+        {"status4k": 4},
+        {
+            "status4k": 4,
+            "mediaUrl4k": "https://evil.example/partial-4k",
+            "iOSPlexUrl4k": "plex://preplay/?metadataKey=partial-4k",
+        },
+    ],
+)
+def test_partially_available_media_without_valid_links_has_no_playback(
+    payload: dict[str, object],
+) -> None:
+    result = to_availability(SeerrMediaInfo.model_validate(payload))
+
+    assert result.playback is None
+
+
+def test_4k_only_availability_and_links_are_preserved() -> None:
+    result = to_availability(
+        SeerrMediaInfo.model_validate(
+            {
+                "status": 1,
+                "status4k": 5,
+                "mediaUrl4k": "https://app.plex.tv/desktop/#!/4k",
+                "iOSPlexUrl4k": "plex://preplay/?metadataKey=%2Flibrary%2F84",
+            }
+        )
+    )
+
+    assert result.status == "available"
+    assert result.playback is not None
+    assert result.playback.regular is None
+    assert result.playback.four_k is not None
+    assert result.playback.four_k.web_url == "https://app.plex.tv/desktop/#!/4k"
+
+
+def test_mixed_playable_variant_states_keep_both_link_sets() -> None:
+    result = to_availability(
+        SeerrMediaInfo.model_validate(
+            {
+                "status": 4,
+                "status4k": 5,
+                "mediaUrl": "https://app.plex.tv/desktop/#!/regular",
+                "iOSPlexUrl": "plex://preplay/?metadataKey=regular",
+                "mediaUrl4k": "https://app.plex.tv/desktop/#!/4k",
+                "iOSPlexUrl4k": "plex://preplay/?metadataKey=4k",
+            }
+        )
+    )
+
+    assert result.status == "available"
+    assert result.playback is not None
+    assert result.playback.regular is not None
+    assert result.playback.four_k is not None
+    assert result.playback.regular.web_url == "https://app.plex.tv/desktop/#!/regular"
+    assert result.playback.four_k.web_url == "https://app.plex.tv/desktop/#!/4k"
+
+
+@pytest.mark.parametrize(
+    ("web", "app"),
+    [
+        ("javascript:alert(1)", "plex://preplay/?metadataKey=x"),
+        ("https://evil.example/", "plex://preplay/?metadataKey=x"),
+        ("https://user:pass@app.plex.tv/", "plex://preplay/?metadataKey=x"),
+        ("https://app.plex.tv/?X-Plex-Token=placeholder", "plex://preplay/?metadataKey=x"),
+        ("https://app.plex.tv/?%58-Plex-Token=placeholder", "plex://preplay/?metadataKey=x"),
+        (
+            "https://app.plex.tv/desktop#!/details?x-plex-token=placeholder",
+            "plex://preplay/?metadataKey=x",
+        ),
+        (" https://app.plex.tv/", "plex://preplay/?metadataKey=x"),
+        ("https://app.plex.tv:8443/", "plex://preplay/?metadataKey=x"),
+        ("https://app.plex.tv:abc/", "plex://preplay/?metadataKey=x"),
+        ("https://app.plex.tv/\x00", "plex://preplay/?metadataKey=x"),
+        ("https://app.plex.tv/", "plex://settings/?metadataKey=x"),
+        ("https://app.plex.tv/", "plex://preplay/?%78-plex-token=placeholder"),
+        (
+            "https://app.plex.tv/",
+            "plex://preplay/?metadataKey=x&X-Plex-Token=placeholder",
+        ),
+        ("https://app.plex.tv/", "plex://preplay/?metadataKey=x#Intent;package=evil"),
+        ("https://app.plex.tv/", "plex://preplay/?metadataKey=x#"),
+    ],
+)
+def test_unsafe_playback_links_are_dropped(web: str, app: str) -> None:
+    result = to_availability(
+        SeerrMediaInfo.model_validate({"status": 5, "plexUrl": web, "iOSPlexUrl": app})
+    )
+
+    if web == "https://app.plex.tv/" and app.startswith("plex://"):
+        assert result.playback == PlaybackLinks(
+            regular=PlaybackVariant(web_url="https://app.plex.tv/")
+        )
+    else:
+        assert result.playback is None
+
+
+def test_non_available_media_drops_stray_playback_links() -> None:
+    result = to_availability(
+        SeerrMediaInfo.model_validate(
+            {
+                "status": 2,
+                "plexUrl": "https://app.plex.tv/desktop/",
+                "iOSPlexUrl": "plex://preplay/?metadataKey=x",
+            }
+        )
+    )
+
+    assert result.status == "pending"
+    assert result.playback is None
 
 
 # ── AvailabilityService: cache, single-flight, degradation ───────────────────

--- a/backend/tests/test_clients_seerr.py
+++ b/backend/tests/test_clients_seerr.py
@@ -172,6 +172,50 @@ async def test_media_status_parses_movie_mediainfo() -> None:
     assert info.status == 5
 
 
+@pytest.mark.parametrize("web_field", ["plexUrl", "mediaUrl"])
+async def test_media_status_accepts_both_seerr_playback_link_aliases(web_field: str) -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "mediaInfo": {
+                    "status": 5,
+                    web_field: "https://app.plex.tv/desktop/#!/details",
+                    "iOSPlexUrl": "plex://preplay/?metadataKey=%2Flibrary%2Fmetadata%2F42",
+                    "ignoredFutureField": "safe to drop",
+                }
+            },
+        )
+
+    info = await _media_client(handler).media_status("movie", 42)
+
+    assert info is not None
+    assert info.web_url == "https://app.plex.tv/desktop/#!/details"
+    assert info.app_url == "plex://preplay/?metadataKey=%2Flibrary%2Fmetadata%2F42"
+
+
+async def test_media_status_parses_4k_playback_fields() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "mediaInfo": {
+                    "status": 1,
+                    "status4k": 5,
+                    "mediaUrl4k": "https://app.plex.tv/desktop/#!/4k-details",
+                    "iOSPlexUrl4k": "plex://preplay/?metadataKey=%2Flibrary%2Fmetadata%2F84",
+                }
+            },
+        )
+
+    info = await _media_client(handler).media_status("movie", 42)
+
+    assert info is not None
+    assert info.status_4k == 5
+    assert info.web_url_4k == "https://app.plex.tv/desktop/#!/4k-details"
+    assert info.app_url_4k == "plex://preplay/?metadataKey=%2Flibrary%2Fmetadata%2F84"
+
+
 async def test_media_status_parses_tv_per_season() -> None:
     def handler(_: httpx.Request) -> httpx.Response:
         return httpx.Response(

--- a/backend/tests/test_db_migrations.py
+++ b/backend/tests/test_db_migrations.py
@@ -30,6 +30,13 @@ def _downgrade(connection: Connection, revision: str) -> None:
     command.downgrade(config, revision)
 
 
+def _upgrade(connection: Connection, revision: str) -> None:
+    config = Config()
+    config.set_main_option("script_location", str(ALEMBIC_DIR))
+    config.attributes["connection"] = connection
+    command.upgrade(config, revision)
+
+
 async def test_fresh_database_migrates_to_head(tmp_path: Path) -> None:
     engine = create_engine(tmp_path / "tasterr.db")
     try:
@@ -137,8 +144,55 @@ async def test_downgrade_drops_only_settings_table(tmp_path: Path) -> None:
         tables = await _table_names(engine)
         assert "settings" not in tables
         assert {"users", "signals", "title_features", "profiles"} <= tables
+        async with engine.connect() as connection:
+            user_id = await connection.execute(text("select seerr_user_id from users"))
+            assert user_id.scalar_one() == 8
+    finally:
+        await engine.dispose()
+
+
+async def test_migration_0005_defaults_existing_users_to_unseen(tmp_path: Path) -> None:
+    engine = create_engine(tmp_path / "tasterr.db")
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(_upgrade, "0004")
+        maker = async_sessionmaker(engine, expire_on_commit=False)
         async with maker() as db:
-            assert (await db.execute(select(User))).scalars().one().seerr_user_id == 8
+            await db.execute(
+                text(
+                    "insert into users "
+                    "(seerr_user_id, display_name, auth_type, is_admin, created_at, last_login_at) "
+                    "values (8, 'member', 'local', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+                )
+            )
+            await db.commit()
+
+        await upgrade_to_head(engine)
+
+        async with maker() as db:
+            user = (await db.execute(select(User))).scalars().one()
+            assert user.taste_onboarding_seen is False
+    finally:
+        await engine.dispose()
+
+
+async def test_downgrade_0005_preserves_users(tmp_path: Path) -> None:
+    engine = create_engine(tmp_path / "tasterr.db")
+    try:
+        await upgrade_to_head(engine)
+        maker = async_sessionmaker(engine, expire_on_commit=False)
+        async with maker() as db:
+            db.add(User(seerr_user_id=8, display_name="member", auth_type="local"))
+            await db.commit()
+
+        async with engine.begin() as connection:
+            await connection.run_sync(_downgrade, "0004")
+
+        async with engine.connect() as connection:
+            columns = await connection.execute(text("pragma table_info(users)"))
+            assert "taste_onboarding_seen" not in {row[1] for row in columns}
+            count = await connection.execute(text("select count(*) from users"))
+            assert count.scalar_one() == 1
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_mutation_guards.py
+++ b/backend/tests/test_mutation_guards.py
@@ -22,6 +22,10 @@ EXPECTED_GUARDS = {
     ("POST", "/api/v1/connection-test"): {"require_same_origin", "admin_rate_limit"},
     ("POST", "/api/v1/request"): {"require_same_origin", "mutation_rate_limit"},
     ("POST", "/api/v1/signals"): {"require_same_origin", "mutation_rate_limit"},
+    ("POST", "/api/v1/taste-onboarding"): {
+        "require_same_origin",
+        "mutation_rate_limit",
+    },
     ("POST", "/api/v1/recommendations/reset"): {
         "require_same_origin",
         "mutation_rate_limit",

--- a/backend/tests/test_onboarding_api.py
+++ b/backend/tests/test_onboarding_api.py
@@ -1,0 +1,183 @@
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
+
+import asyncio
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+import tasterr.api.onboarding as onboarding_api
+from tasterr.auth.ratelimit import TokenBucket
+from tasterr.auth.sessions import mint_session
+from tasterr.db.engine import create_engine
+from tasterr.db.migrate import upgrade_to_head
+from tasterr.db.models import Signal, User
+from tasterr.main import create_app
+from tasterr.settings import Settings
+
+
+def _app(tmp_path: Path) -> FastAPI:
+    settings = Settings.model_validate(
+        {"database_path": tmp_path / "tasterr.db", "static_dir": tmp_path / "static"}
+    )
+    return create_app(settings)
+
+
+def _seed_session(db_path: Path) -> tuple[str, int]:
+    async def _run() -> tuple[str, int]:
+        engine = create_engine(db_path)
+        try:
+            await upgrade_to_head(engine)
+            maker = async_sessionmaker(engine, expire_on_commit=False)
+            async with maker() as db:
+                user = User(seerr_user_id=99, display_name="Member", auth_type="local")
+                db.add(user)
+                await db.flush()
+                token = await mint_session(db, user.id, "connect.sid=seed", None)
+                return token, user.id
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(_run())
+
+
+def _stored_state(db_path: Path) -> tuple[bool, set[tuple[str, int, str]]]:
+    async def _run() -> tuple[bool, set[tuple[str, int, str]]]:
+        engine = create_engine(db_path)
+        try:
+            maker = async_sessionmaker(engine, expire_on_commit=False)
+            async with maker() as db:
+                user = (await db.execute(select(User))).scalars().one()
+                signals = (await db.execute(select(Signal))).scalars().all()
+                return user.taste_onboarding_seen, {
+                    (row.media_type, row.tmdb_id, row.kind) for row in signals
+                }
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(_run())
+
+
+@pytest.fixture
+def authed_client(tmp_path: Path) -> Generator[tuple[TestClient, FastAPI, Path, int]]:
+    db_path = tmp_path / "tasterr.db"
+    app = _app(tmp_path)
+    token, user_id = _seed_session(db_path)
+    with TestClient(app) as client:
+        client.cookies.set("tasterr_session", token)
+        yield client, app, db_path, user_id
+
+
+def test_state_requires_authentication(tmp_path: Path) -> None:
+    with TestClient(_app(tmp_path)) as client:
+        response = client.get("/api/v1/taste-onboarding")
+    assert response.status_code == 401
+
+
+def test_empty_user_waits_for_seed_then_sees_picker(
+    authed_client: tuple[TestClient, FastAPI, Path, int],
+) -> None:
+    client, app, _db_path, user_id = authed_client
+    app.state.seeding.add(user_id)
+    assert client.get("/api/v1/taste-onboarding").json() == {"state": "pending"}
+
+    app.state.seeding.discard(user_id)
+    assert client.get("/api/v1/taste-onboarding").json() == {"state": "show"}
+
+
+def test_selections_are_idempotent_watchlist_signals_with_one_refresh_per_submit(
+    authed_client: tuple[TestClient, FastAPI, Path, int],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _app_instance, db_path, user_id = authed_client
+    refreshes: list[int] = []
+
+    async def refresh(*args: object) -> None:
+        refreshes.append(user_id)
+
+    monkeypatch.setattr(onboarding_api, "refresh_profile", refresh)
+    body = {
+        "selections": [
+            {"media_type": "movie", "tmdb_id": 42},
+            {"media_type": "movie", "tmdb_id": 42},
+            {"media_type": "tv", "tmdb_id": 7},
+        ]
+    }
+    response = client.post("/api/v1/taste-onboarding", json=body)
+    repeated = client.post("/api/v1/taste-onboarding", json=body)
+
+    assert response.status_code == 200
+    assert response.json() == {"recorded_signals": 2}
+    assert repeated.json() == {"recorded_signals": 0}
+    assert "tmdb_id" not in response.text
+    assert refreshes == [user_id, user_id]
+    assert _stored_state(db_path) == (
+        True,
+        {("movie", 42, "watchlist"), ("tv", 7, "watchlist")},
+    )
+    assert client.get("/api/v1/taste-onboarding").json() == {"state": "done"}
+
+
+def test_existing_signal_suppresses_picker_even_while_seed_is_reserved(
+    authed_client: tuple[TestClient, FastAPI, Path, int],
+) -> None:
+    client, app, _db_path, user_id = authed_client
+    response = client.post(
+        "/api/v1/signals",
+        json={"media_type": "movie", "tmdb_id": 42, "kind": "detail_open"},
+    )
+    assert response.status_code == 200
+    app.state.seeding.add(user_id)
+    assert client.get("/api/v1/taste-onboarding").json() == {"state": "done"}
+
+
+def test_skip_is_durable_across_taste_reset(
+    authed_client: tuple[TestClient, FastAPI, Path, int],
+) -> None:
+    client, _app_instance, db_path, _user_id = authed_client
+    skipped = client.post("/api/v1/taste-onboarding", json={"selections": []})
+    assert skipped.json() == {"recorded_signals": 0}
+    assert _stored_state(db_path) == (True, set())
+
+    reset = client.post("/api/v1/recommendations/reset")
+    assert reset.status_code == 200
+    assert client.get("/api/v1/taste-onboarding").json() == {"state": "done"}
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"selections": [{"media_type": "music", "tmdb_id": 1}]},
+        {"selections": [{"media_type": "movie", "tmdb_id": 0}]},
+        {"selections": [{"media_type": "movie", "tmdb_id": 2_147_483_648}]},
+        {"selections": [{"media_type": "movie", "tmdb_id": tmdb_id} for tmdb_id in range(1, 14)]},
+    ],
+)
+def test_invalid_selection_is_rejected(
+    authed_client: tuple[TestClient, FastAPI, Path, int], body: dict[str, object]
+) -> None:
+    client, _app_instance, db_path, _user_id = authed_client
+    assert client.post("/api/v1/taste-onboarding", json=body).status_code == 422
+    assert _stored_state(db_path) == (False, set())
+
+
+def test_cross_origin_and_rate_limited_completions_have_no_side_effect(
+    authed_client: tuple[TestClient, FastAPI, Path, int],
+) -> None:
+    client, app, db_path, _user_id = authed_client
+    body = {"selections": [{"media_type": "movie", "tmdb_id": 42}]}
+    cross_origin = client.post(
+        "/api/v1/taste-onboarding",
+        json=body,
+        headers={"origin": "https://evil.example"},
+    )
+    assert cross_origin.status_code == 403
+
+    app.state.mutation_bucket = TokenBucket(capacity=0, refill_per_second=0)
+    limited = client.post("/api/v1/taste-onboarding", json=body)
+    assert limited.status_code == 429
+    assert _stored_state(db_path) == (False, set())

--- a/backend/tests/test_request_api.py
+++ b/backend/tests/test_request_api.py
@@ -138,6 +138,27 @@ def test_cross_origin_request_is_rejected(tmp_path: Path) -> None:
     assert calls == []  # rejected before any Seerr call
 
 
+def test_out_of_range_request_is_rejected_before_upstream_or_taste_write(
+    tmp_path: Path,
+) -> None:
+    calls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(str(request.url))
+        return httpx.Response(201, json={"media": {"status": 2}})
+
+    app = _app(tmp_path)
+    _override_ctx(app, handler)
+    db_path = tmp_path / "tasterr.db"
+    token = _seed_session(db_path)
+    with _client(app, token) as client:
+        response = client.post("/api/v1/request", json=_body(tmdb_id=2_147_483_648))
+
+    assert response.status_code == 422
+    assert calls == []
+    assert _stored_taste_signals(db_path) == []
+
+
 def test_rate_limited_request_has_no_upstream_or_taste_side_effect(tmp_path: Path) -> None:
     calls: list[str] = []
 
@@ -182,7 +203,7 @@ def test_successful_request_returns_status_and_fallback(tmp_path: Path) -> None:
     assert response.status_code == 200
     assert response.json() == {
         "status": "ok",
-        "availability": {"status": "pending", "known": True},
+        "availability": {"status": "pending", "known": True, "playback": None},
         "seerr_url": "https://requests.example/movie/42",
     }
     assert seen == [SEED_COOKIE]  # attributed via the member's own cookie

--- a/backend/tests/test_signals_api.py
+++ b/backend/tests/test_signals_api.py
@@ -77,6 +77,19 @@ def test_unauthenticated_signal_is_rejected(tmp_path: Path) -> None:
     assert _stored_signals(tmp_path / "tasterr.db") == []
 
 
+def test_out_of_range_tmdb_id_is_rejected_before_database_write(tmp_path: Path) -> None:
+    app = _app(tmp_path)
+    db_path = tmp_path / "tasterr.db"
+    token = _seed_session(db_path)
+    body = _body()
+    body["tmdb_id"] = 2_147_483_648
+    with _client(app, token) as client:
+        response = client.post("/api/v1/signals", json=body)
+
+    assert response.status_code == 422
+    assert _stored_signals(db_path) == []
+
+
 def test_cross_origin_signal_is_rejected(tmp_path: Path) -> None:
     app = _app(tmp_path)
     token = _seed_session(tmp_path / "tasterr.db")

--- a/frontend/src/components/DetailModal.test.tsx
+++ b/frontend/src/components/DetailModal.test.tsx
@@ -16,6 +16,7 @@ afterEach(() => {
 	cleanup();
 	document.body.style.overflow = "";
 	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
 });
 
 const DETAIL = {
@@ -76,7 +77,7 @@ function renderModal(
 	const queryClient = new QueryClient({
 		defaultOptions: { queries: { retry: false } },
 	});
-	render(
+	return render(
 		<QueryClientProvider client={queryClient}>
 			<MemoryRouter initialEntries={initialEntries}>
 				<Routes>
@@ -117,6 +118,174 @@ test("renders the title detail sections", async () => {
 	);
 	expect(external.getAttribute("target")).toBe("_blank");
 	expect(external.getAttribute("rel")).toBe("noopener noreferrer");
+});
+
+test("available titles expose separate focusable Plex web and app links", async () => {
+	stubTasteFetch({
+		"/api/v1/title/": {
+			...DETAIL,
+			availability: {
+				status: "available",
+				known: true,
+				playback: {
+					regular: {
+						web_url: "https://app.plex.tv/desktop/#!/details",
+						app_url: "plex://preplay/?metadataKey=x",
+						android_intent_url: "intent://preplay/#Intent;end",
+					},
+					four_k: null,
+				},
+			},
+		},
+		"/api/v1/signals": { recorded: true },
+	});
+	vi.stubGlobal("navigator", { userAgent: "Mozilla/5.0 (X11; Linux x86_64)" });
+	renderModal();
+
+	const web = await screen.findByRole("link", {
+		name: "Play in Plex Web (opens in a new tab)",
+	});
+	const app = screen.getByRole("link", { name: "Play in Plex App" });
+	expect(web.getAttribute("href")).toBe(
+		"https://app.plex.tv/desktop/#!/details",
+	);
+	expect(app.getAttribute("href")).toBe("plex://preplay/?metadataKey=x");
+	expect(web.getAttribute("target")).toBe("_blank");
+	expect(web.getAttribute("rel")).toBe("noopener noreferrer");
+	expect(app.getAttribute("rel")).toBe("noreferrer");
+	const guidance = screen.getByText(
+		"Experimental. Plex Web may need a second try after sign-in or switching users. Plex App may open Home instead.",
+	);
+	expect(guidance.getAttribute("id")).toBe("plex-playback-experimental");
+	expect(web.getAttribute("aria-describedby")).toBe(
+		"plex-playback-experimental",
+	);
+	expect(app.getAttribute("aria-describedby")).toBe(
+		"plex-playback-experimental",
+	);
+	web.focus();
+	expect(document.activeElement).toBe(web);
+	app.focus();
+	expect(document.activeElement).toBe(app);
+});
+
+test("Android keeps Plex Web and uses the server-provided app intent", async () => {
+	stubTasteFetch({
+		"/api/v1/title/": {
+			...DETAIL,
+			availability: {
+				status: "available",
+				known: true,
+				playback: {
+					regular: {
+						web_url: "https://app.plex.tv/desktop/#!/details",
+						app_url: "plex://preplay/?metadataKey=x",
+						android_intent_url:
+							"intent://preplay/#Intent;package=com.plexapp.android;S.browser_fallback_url=https%3A%2F%2Fapp.plex.tv;end",
+					},
+					four_k: null,
+				},
+			},
+		},
+		"/api/v1/signals": { recorded: true },
+	});
+	vi.stubGlobal("navigator", { userAgent: "Mozilla/5.0 (Linux; Android 16)" });
+	renderModal();
+
+	expect(
+		(
+			await screen.findByRole("link", {
+				name: "Play in Plex Web (opens in a new tab)",
+			})
+		).getAttribute("href"),
+	).toBe("https://app.plex.tv/desktop/#!/details");
+	expect(
+		screen.getByRole("link", { name: "Play in Plex App" }).getAttribute("href"),
+	).toContain("package=com.plexapp.android");
+});
+
+test("partially available regular playback is preferred over playable 4K", async () => {
+	stubTasteFetch({
+		"/api/v1/title/": {
+			...DETAIL,
+			availability: {
+				status: "partial",
+				known: true,
+				playback: {
+					regular: {
+						web_url: "https://app.plex.tv/desktop#!/partial",
+						app_url: "plex://preplay/?metadataKey=partial",
+						android_intent_url: null,
+					},
+					four_k: {
+						web_url: "https://app.plex.tv/desktop#!/4k",
+						app_url: "plex://preplay/?metadataKey=4k",
+						android_intent_url: null,
+					},
+				},
+			},
+		},
+		"/api/v1/signals": { recorded: true },
+	});
+	vi.stubGlobal("navigator", { userAgent: "Mozilla/5.0 (X11; Linux x86_64)" });
+	renderModal();
+
+	const web = await screen.findByRole("link", {
+		name: "Play in Plex Web (opens in a new tab)",
+	});
+	const app = screen.getByRole("link", { name: "Play in Plex App" });
+	expect(web.getAttribute("href")).toBe(
+		"https://app.plex.tv/desktop#!/partial",
+	);
+	expect(app.getAttribute("href")).toBe("plex://preplay/?metadataKey=partial");
+});
+
+test("playback links fall back to 4K and omit an unavailable app target", async () => {
+	stubTasteFetch({
+		"/api/v1/title/": {
+			...DETAIL,
+			availability: {
+				status: "available",
+				known: true,
+				playback: {
+					regular: null,
+					four_k: {
+						web_url: "https://app.plex.tv/desktop/#!/4k",
+						app_url: null,
+						android_intent_url: null,
+					},
+				},
+			},
+		},
+		"/api/v1/signals": { recorded: true },
+	});
+	renderModal();
+
+	expect(
+		(
+			await screen.findByRole("link", {
+				name: "Play in Plex Web (opens in a new tab)",
+			})
+		).getAttribute("href"),
+	).toBe("https://app.plex.tv/desktop/#!/4k");
+	expect(screen.queryByRole("link", { name: "Play in Plex App" })).toBeNull();
+
+	cleanup();
+	stubTasteFetch({
+		"/api/v1/title/": {
+			...DETAIL,
+			availability: { status: "available", known: true, playback: null },
+		},
+		"/api/v1/signals": { recorded: true },
+	});
+	renderModal();
+	await screen.findByRole("heading", { name: "Deep Movie" });
+	expect(
+		screen.queryByRole("link", {
+			name: "Play in Plex Web (opens in a new tab)",
+		}),
+	).toBeNull();
+	expect(screen.queryByRole("link", { name: "Play in Plex App" })).toBeNull();
 });
 
 test("traps focus, marks the browse shell inert, and cleans up on Escape", async () => {

--- a/frontend/src/components/DetailModal.tsx
+++ b/frontend/src/components/DetailModal.tsx
@@ -170,11 +170,14 @@ function DetailBody({ detail }: { detail: MediaDetail }) {
 					<h3 className="text-sm font-semibold text-app-text">
 						Where &amp; how to watch
 					</h3>
-					<RequestButton
-						type={detail.media_type}
-						id={detail.id}
-						availability={detail.availability}
-					/>
+					<div className="flex flex-wrap items-start gap-3">
+						<PlexPlaybackLinks availability={detail.availability} />
+						<RequestButton
+							type={detail.media_type}
+							id={detail.id}
+							availability={detail.availability}
+						/>
+					</div>
 					{providers.length > 0 && (
 						<ul className="flex flex-wrap gap-3">
 							{providers.map((provider) => (
@@ -251,6 +254,54 @@ function DetailBody({ detail }: { detail: MediaDetail }) {
 
 				<WhyThis type={detail.media_type} id={detail.id} />
 			</div>
+		</div>
+	);
+}
+
+function PlexPlaybackLinks({
+	availability,
+}: {
+	availability: MediaDetail["availability"];
+}) {
+	const variant =
+		availability?.playback?.regular ?? availability?.playback?.four_k;
+	if (!variant) {
+		return null;
+	}
+	const android = /Android/i.test(navigator.userAgent);
+	const appHref = android ? variant.android_intent_url : variant.app_url;
+	return (
+		<div className="flex flex-col items-start gap-1">
+			<div className="flex flex-wrap items-center gap-3">
+				<a
+					href={variant.web_url}
+					target="_blank"
+					rel="noopener noreferrer"
+					aria-label="Play in Plex Web (opens in a new tab)"
+					aria-describedby="plex-playback-experimental"
+					className="inline-flex min-h-11 items-center rounded bg-app-accent px-4 py-1.5 text-sm font-semibold text-white hover:brightness-110 focus-visible:outline-2 focus-visible:outline-app-text"
+				>
+					<span aria-hidden="true">▶</span>&nbsp; Plex Web
+				</a>
+				{appHref && (
+					<a
+						href={appHref}
+						rel="noreferrer"
+						aria-label="Play in Plex App"
+						aria-describedby="plex-playback-experimental"
+						className="inline-flex min-h-11 items-center rounded border border-app-border px-4 py-1.5 text-sm font-semibold text-app-text hover:bg-app-muted focus-visible:outline-2 focus-visible:outline-app-accent"
+					>
+						Plex App
+					</a>
+				)}
+			</div>
+			<p
+				id="plex-playback-experimental"
+				className="text-xs text-app-muted-text"
+			>
+				Experimental. Plex Web may need a second try after sign-in or switching
+				users. Plex App may open Home instead.
+			</p>
 		</div>
 	);
 }

--- a/frontend/src/components/TastePicker.test.tsx
+++ b/frontend/src/components/TastePicker.test.tsx
@@ -1,0 +1,300 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+import type { MediaSummary } from "../lib/api";
+import { TastePicker } from "./TastePicker";
+
+afterEach(() => {
+	cleanup();
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+function item(id: number): MediaSummary {
+	return {
+		id,
+		media_type: id % 2 ? "movie" : "tv",
+		title: `Title ${id}`,
+		overview: "",
+		poster_path: null,
+		backdrop_path: null,
+		year: 2020,
+		vote_average: 7,
+	};
+}
+
+function jsonResponse(body: unknown): Response {
+	return { ok: true, status: 200, json: async () => body } as Response;
+}
+
+function renderPicker(items: MediaSummary[], userId = 1) {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	const view = (nextItems: MediaSummary[], nextUserId: number) => (
+		<QueryClientProvider client={queryClient}>
+			<a href="/search">Browse search</a>
+			<TastePicker items={nextItems} userId={nextUserId} />
+		</QueryClientProvider>
+	);
+	const result = render(view(items, userId));
+	return {
+		...result,
+		rerenderPicker: (nextItems: MediaSummary[], nextUserId = userId) =>
+			result.rerender(view(nextItems, nextUserId)),
+	};
+}
+
+test("shows at most 12 unique feed titles without blocking browse controls", async () => {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async () => jsonResponse({ state: "show" })),
+	);
+	renderPicker([
+		item(1),
+		item(1),
+		...Array.from({ length: 13 }, (_, i) => item(i + 2)),
+	]);
+
+	expect(await screen.findByText("Pick a few titles you like")).toBeTruthy();
+	expect(document.querySelectorAll("button[aria-pressed]")).toHaveLength(12);
+	expect(screen.getByRole("link", { name: "Browse search" })).toBeTruthy();
+	expect(screen.queryByRole("button", { name: "Choose Title 14" })).toBeNull();
+});
+
+test("selection posts typed title keys and disappears after success", async () => {
+	const posts: unknown[] = [];
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+			if (init?.method === "POST") {
+				posts.push(JSON.parse(String(init.body)));
+				return jsonResponse({ recorded_signals: 1 });
+			}
+			return jsonResponse({ state: "show" });
+		}),
+	);
+	renderPicker([item(1), item(2)]);
+
+	const choice = await screen.findByRole("button", { name: "Choose Title 1" });
+	choice.focus();
+	expect(document.activeElement).toBe(choice);
+	fireEvent.click(choice);
+	expect(
+		screen
+			.getByRole("button", { name: "Remove Title 1" })
+			.getAttribute("aria-pressed"),
+	).toBe("true");
+	fireEvent.click(screen.getByRole("button", { name: "Use these picks" }));
+
+	await waitFor(() =>
+		expect(posts).toEqual([
+			{ selections: [{ media_type: "movie", tmdb_id: 1 }] },
+		]),
+	);
+	expect(screen.queryByText("Pick a few titles you like")).toBeNull();
+});
+
+test("selected title keys survive a feed candidate refresh", async () => {
+	const posts: unknown[] = [];
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+			if (init?.method === "POST") {
+				posts.push(JSON.parse(String(init.body)));
+				return jsonResponse({ recorded_signals: 1 });
+			}
+			return jsonResponse({ state: "show" });
+		}),
+	);
+	const view = renderPicker([item(1), item(2)]);
+
+	fireEvent.click(
+		await screen.findByRole("button", { name: "Choose Title 1" }),
+	);
+	view.rerenderPicker([item(2), item(3)]);
+	expect(screen.queryByRole("button", { name: "Remove Title 1" })).toBeNull();
+	fireEvent.click(screen.getByRole("button", { name: "Use these picks" }));
+
+	await waitFor(() =>
+		expect(posts).toEqual([
+			{ selections: [{ media_type: "movie", tmdb_id: 1 }] },
+		]),
+	);
+});
+
+test("retained selections can be cleared after reaching 12 across a feed refresh", async () => {
+	const posts: unknown[] = [];
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+			if (init?.method === "POST") {
+				posts.push(JSON.parse(String(init.body)));
+				return jsonResponse({ recorded_signals: 12 });
+			}
+			return jsonResponse({ state: "show" });
+		}),
+	);
+	const firstCandidates = Array.from({ length: 12 }, (_, index) =>
+		item(index + 1),
+	);
+	const view = renderPicker(firstCandidates);
+	await screen.findByText("Pick a few titles you like");
+	for (const candidate of firstCandidates) {
+		fireEvent.click(
+			screen.getByRole("button", { name: `Choose ${candidate.title}` }),
+		);
+	}
+
+	view.rerenderPicker(
+		Array.from({ length: 12 }, (_, index) => item(index + 13)),
+	);
+	const extra = screen.getByRole("button", { name: "Choose Title 13" });
+	expect(extra.getAttribute("aria-disabled")).toBe("true");
+	extra.focus();
+	expect(document.activeElement).toBe(extra);
+	fireEvent.click(extra);
+	expect(extra.getAttribute("aria-pressed")).toBe("false");
+
+	const clear = screen.getByRole("button", { name: "Clear picks" });
+	clear.focus();
+	expect(document.activeElement).toBe(clear);
+	fireEvent.click(clear);
+	expect(extra.getAttribute("aria-disabled")).toBe("false");
+	fireEvent.click(extra);
+	expect(extra.getAttribute("aria-pressed")).toBe("true");
+	fireEvent.click(screen.getByRole("button", { name: "Use these picks" }));
+
+	await waitFor(() => expect(posts).toHaveLength(1));
+	const submission = posts[0] as { selections: { tmdb_id: number }[] };
+	expect(submission.selections).toEqual([{ media_type: "movie", tmdb_id: 13 }]);
+});
+
+test("submission failures are announced and leave the picker usable", async () => {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+			if (init?.method === "POST") {
+				return {
+					ok: false,
+					status: 500,
+					json: async () => ({ detail: "failed" }),
+				} as Response;
+			}
+			return jsonResponse({ state: "show" });
+		}),
+	);
+	renderPicker([item(1)]);
+
+	fireEvent.click(
+		await screen.findByRole("button", { name: "Choose Title 1" }),
+	);
+	fireEvent.click(screen.getByRole("button", { name: "Use these picks" }));
+
+	const alert = await screen.findByRole("alert");
+	expect(alert.textContent).toContain("Couldn't save your choices");
+	expect(screen.getByRole("link", { name: "Browse search" })).toBeTruthy();
+	expect(screen.getByRole("button", { name: "Remove Title 1" })).toBeTruthy();
+});
+
+test("Skip dismisses with an empty selection", async () => {
+	const posts: unknown[] = [];
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+			if (init?.method === "POST") {
+				posts.push(JSON.parse(String(init.body)));
+				return jsonResponse({ recorded_signals: 0 });
+			}
+			return jsonResponse({ state: "show" });
+		}),
+	);
+	renderPicker([item(1)]);
+
+	fireEvent.click(await screen.findByRole("button", { name: "Skip" }));
+	await waitFor(() => expect(posts).toEqual([{ selections: [] }]));
+	expect(screen.queryByText("Pick a few titles you like")).toBeNull();
+});
+
+test("pending state polls until cold-start seeding finishes", async () => {
+	let reads = 0;
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async () => {
+			reads += 1;
+			return jsonResponse({ state: reads === 1 ? "pending" : "show" });
+		}),
+	);
+	renderPicker([item(1)]);
+
+	expect(screen.queryByText("Pick a few titles you like")).toBeNull();
+	expect(
+		await screen.findByText(
+			"Pick a few titles you like",
+			{},
+			{ timeout: 1500 },
+		),
+	).toBeTruthy();
+	expect(reads).toBeGreaterThanOrEqual(2);
+});
+
+test("polling stops when a pending-state refresh fails", async () => {
+	let reads = 0;
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async () => {
+			reads += 1;
+			if (reads === 1) return jsonResponse({ state: "pending" });
+			throw new TypeError("offline");
+		}),
+	);
+	renderPicker([item(1)]);
+
+	await waitFor(() => expect(reads).toBe(2), { timeout: 1500 });
+	await new Promise((resolve) => window.setTimeout(resolve, 700));
+	expect(reads).toBe(2);
+	expect(screen.queryByText("Pick a few titles you like")).toBeNull();
+});
+
+test("onboarding cache state is scoped to the current user", async () => {
+	let reads = 0;
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async () => {
+			reads += 1;
+			return jsonResponse({ state: reads === 1 ? "show" : "done" });
+		}),
+	);
+	const view = renderPicker([item(1)], 101);
+
+	expect(await screen.findByText("Pick a few titles you like")).toBeTruthy();
+	view.rerenderPicker([item(1)], 202);
+	expect(screen.queryByText("Pick a few titles you like")).toBeNull();
+	await waitFor(() => expect(reads).toBe(2));
+	expect(screen.queryByText("Pick a few titles you like")).toBeNull();
+});
+
+test("status failure and an empty candidate list render nothing", async () => {
+	const fetchMock = vi.fn(async () => {
+		throw new TypeError("offline");
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	renderPicker([item(1)]);
+	await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+	expect(screen.queryByText("Pick a few titles you like")).toBeNull();
+
+	cleanup();
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async () => jsonResponse({ state: "show" })),
+	);
+	renderPicker([]);
+	await waitFor(() => expect(fetch).toHaveBeenCalled());
+	expect(screen.queryByText("Pick a few titles you like")).toBeNull();
+});

--- a/frontend/src/components/TastePicker.tsx
+++ b/frontend/src/components/TastePicker.tsx
@@ -1,0 +1,139 @@
+import { useMemo, useState } from "react";
+import type { MediaSummary, TasteOnboardingSelection } from "../lib/api";
+import { posterUrl } from "../lib/images";
+import { useCompleteTasteOnboarding, useTasteOnboarding } from "../lib/taste";
+
+const MAX_SELECTIONS = 12;
+
+export function TastePicker({
+	items,
+	userId,
+}: {
+	items: MediaSummary[];
+	userId: number | undefined;
+}) {
+	const status = useTasteOnboarding(userId);
+	const complete = useCompleteTasteOnboarding(userId);
+	const [selected, setSelected] = useState<
+		Map<string, TasteOnboardingSelection>
+	>(() => new Map());
+	const candidates = useMemo(
+		() =>
+			Array.from(
+				new Map(
+					items.map((item) => [`${item.media_type}:${item.id}`, item]),
+				).values(),
+			).slice(0, MAX_SELECTIONS),
+		[items],
+	);
+
+	if (status.data?.state !== "show" || candidates.length === 0) {
+		return null;
+	}
+
+	const toggle = (item: MediaSummary) => {
+		const key = `${item.media_type}:${item.id}`;
+		setSelected((current) => {
+			if (!current.has(key) && current.size >= MAX_SELECTIONS) return current;
+			const next = new Map(current);
+			if (next.has(key)) next.delete(key);
+			else next.set(key, { media_type: item.media_type, tmdb_id: item.id });
+			return next;
+		});
+	};
+
+	return (
+		<section
+			aria-labelledby="taste-picker-heading"
+			className="mx-4 rounded-lg border border-app-border bg-app-panel p-4 sm:mx-8 sm:p-6"
+		>
+			<h2
+				id="taste-picker-heading"
+				className="text-xl font-semibold text-app-text"
+			>
+				Pick a few titles you like
+			</h2>
+			<p className="mt-1 text-sm text-app-subtle">
+				This helps Tasterr tune recommendations. Pick up to 12, or skip and keep
+				browsing.
+			</p>
+			<ul className="mt-4 flex gap-3 overflow-x-auto pb-2">
+				{candidates.map((item) => {
+					const key = `${item.media_type}:${item.id}`;
+					const active = selected.has(key);
+					const atLimit = !active && selected.size >= MAX_SELECTIONS;
+					const poster = posterUrl(item.poster_path, "w185");
+					return (
+						<li key={key} className="w-28 shrink-0 sm:w-32">
+							<button
+								type="button"
+								aria-label={`${active ? "Remove" : "Choose"} ${item.title}`}
+								aria-pressed={active}
+								aria-disabled={atLimit}
+								onClick={() => toggle(item)}
+								disabled={complete.isPending}
+								className={`w-full rounded-md border-2 text-left focus-visible:outline-3 focus-visible:outline-offset-2 focus-visible:outline-app-accent disabled:opacity-60 aria-disabled:opacity-60 ${active ? "border-app-accent" : "border-transparent"}`}
+							>
+								<div className="relative aspect-[2/3] overflow-hidden rounded bg-app-muted">
+									{poster ? (
+										<img
+											src={poster}
+											alt=""
+											className="h-full w-full object-cover"
+										/>
+									) : (
+										<span className="flex h-full items-center justify-center p-2 text-center text-xs text-app-muted-text">
+											{item.title}
+										</span>
+									)}
+									{active && (
+										<span
+											aria-hidden="true"
+											className="absolute right-1 top-1 rounded-full bg-app-accent px-1.5 py-0.5 text-sm text-white"
+										>
+											{"\u2713"}
+										</span>
+									)}
+								</div>
+								<span className="block truncate px-1 py-1 text-sm text-app-text">
+									{item.title}
+								</span>
+							</button>
+						</li>
+					);
+				})}
+			</ul>
+			<div className="mt-4 flex flex-wrap items-center gap-3">
+				<button
+					type="button"
+					onClick={() => complete.mutate([...selected.values()])}
+					disabled={selected.size === 0 || complete.isPending}
+					className="min-h-11 rounded bg-app-accent px-4 font-semibold text-white hover:brightness-110 focus-visible:outline-2 focus-visible:outline-app-text disabled:opacity-50"
+				>
+					Use these picks
+				</button>
+				<button
+					type="button"
+					onClick={() => setSelected(new Map())}
+					disabled={selected.size === 0 || complete.isPending}
+					className="min-h-11 rounded px-4 text-app-subtle hover:bg-app-muted hover:text-app-text focus-visible:outline-2 focus-visible:outline-app-accent disabled:opacity-50"
+				>
+					Clear picks
+				</button>
+				<button
+					type="button"
+					onClick={() => complete.mutate([])}
+					disabled={complete.isPending}
+					className="min-h-11 rounded px-4 text-app-subtle hover:bg-app-muted hover:text-app-text focus-visible:outline-2 focus-visible:outline-app-accent disabled:opacity-50"
+				>
+					Skip
+				</button>
+				{complete.isError && (
+					<p role="alert" className="text-sm text-status-error">
+						Couldn't save your choices. Try again.
+					</p>
+				)}
+			</div>
+		</section>
+	);
+}

--- a/frontend/src/lib/api.gen.ts
+++ b/frontend/src/lib/api.gen.ts
@@ -311,6 +311,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/taste-onboarding": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Taste Onboarding */
+        get: operations["get_taste_onboarding_api_v1_taste_onboarding_get"];
+        put?: never;
+        /** Complete Taste Onboarding */
+        post: operations["complete_taste_onboarding_api_v1_taste_onboarding_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/recommendations/explain": {
         parameters: {
             query?: never;
@@ -374,6 +392,7 @@ export interface components {
             status: "available" | "partial" | "processing" | "pending" | "not_requested" | "unknown";
             /** Known */
             known: boolean;
+            playback?: components["schemas"]["PlaybackLinks"] | null;
         };
         /** AvailabilityItem */
         AvailabilityItem: {
@@ -604,6 +623,20 @@ export interface components {
             status: "pending" | "ok";
             user?: components["schemas"]["UserResponse"] | null;
         };
+        /** PlaybackLinks */
+        PlaybackLinks: {
+            regular?: components["schemas"]["PlaybackVariant"] | null;
+            four_k?: components["schemas"]["PlaybackVariant"] | null;
+        };
+        /** PlaybackVariant */
+        PlaybackVariant: {
+            /** Web Url */
+            web_url: string;
+            /** App Url */
+            app_url?: string | null;
+            /** Android Intent Url */
+            android_intent_url?: string | null;
+        };
         /** ProviderInfo */
         ProviderInfo: {
             /** Provider Id */
@@ -820,6 +853,37 @@ export interface components {
              * @default false
              */
             hidden: boolean;
+        };
+        /** TasteOnboardingBody */
+        TasteOnboardingBody: {
+            /**
+             * Selections
+             * @default []
+             */
+            selections: components["schemas"]["TasteOnboardingSelection"][];
+        };
+        /** TasteOnboardingSelection */
+        TasteOnboardingSelection: {
+            /**
+             * Media Type
+             * @enum {string}
+             */
+            media_type: "movie" | "tv";
+            /** Tmdb Id */
+            tmdb_id: number;
+        };
+        /** TasteOnboardingStateResponse */
+        TasteOnboardingStateResponse: {
+            /**
+             * State
+             * @enum {string}
+             */
+            state: "pending" | "show" | "done";
+        };
+        /** TasteOnboardingSubmitResponse */
+        TasteOnboardingSubmitResponse: {
+            /** Recorded Signals */
+            recorded_signals: number;
         };
         /**
          * Theme
@@ -1398,6 +1462,59 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SignalResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_taste_onboarding_api_v1_taste_onboarding_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TasteOnboardingStateResponse"];
+                };
+            };
+        };
+    };
+    complete_taste_onboarding_api_v1_taste_onboarding_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TasteOnboardingBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TasteOnboardingSubmitResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -26,6 +26,12 @@ export type SignalResponse = components["schemas"]["SignalResponse"];
 export type ExplainResponse = components["schemas"]["ExplainResponse"];
 export type ResetResponse = components["schemas"]["ResetResponse"];
 export type TasteFlags = components["schemas"]["TasteFlags"];
+export type TasteOnboardingSelection =
+	components["schemas"]["TasteOnboardingSelection"];
+export type TasteOnboardingStateResponse =
+	components["schemas"]["TasteOnboardingStateResponse"];
+export type TasteOnboardingSubmitResponse =
+	components["schemas"]["TasteOnboardingSubmitResponse"];
 export type Appearance = components["schemas"]["Appearance"];
 export type RuntimeSettings = components["schemas"]["RuntimeSettings"];
 export type SettingsResponse = components["schemas"]["SettingsResponse"];
@@ -234,4 +240,16 @@ export function getExplain(
 /** Wipe the caller's signals + profile and re-seed from Seerr history. */
 export function resetRecommendations(): Promise<ResetResponse> {
 	return postJson<ResetResponse>("/api/v1/recommendations/reset");
+}
+
+export function getTasteOnboarding(): Promise<TasteOnboardingStateResponse> {
+	return request<TasteOnboardingStateResponse>("/api/v1/taste-onboarding");
+}
+
+export function completeTasteOnboarding(
+	selections: TasteOnboardingSelection[],
+): Promise<TasteOnboardingSubmitResponse> {
+	return postJson<TasteOnboardingSubmitResponse>("/api/v1/taste-onboarding", {
+		selections,
+	});
 }

--- a/frontend/src/lib/taste.ts
+++ b/frontend/src/lib/taste.ts
@@ -4,10 +4,14 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import {
+	completeTasteOnboarding,
 	getExplain,
+	getTasteOnboarding,
 	type MediaType,
 	postSignal,
 	resetRecommendations,
+	type TasteOnboardingSelection,
+	type TasteOnboardingStateResponse,
 } from "./api";
 
 /** Fire-and-forget detail-open signal: errors are deliberately swallowed. */
@@ -57,5 +61,36 @@ export function useResetRecommendations() {
 	return useMutation({
 		mutationFn: resetRecommendations,
 		onSuccess: () => queryClient.invalidateQueries({ queryKey: ["home"] }),
+	});
+}
+
+const tasteOnboardingKey = (userId: number | undefined) =>
+	["taste-onboarding", userId] as const;
+
+export function useTasteOnboarding(userId: number | undefined) {
+	return useQuery({
+		queryKey: tasteOnboardingKey(userId),
+		queryFn: getTasteOnboarding,
+		enabled: userId !== undefined,
+		retry: false,
+		refetchInterval: (query) =>
+			query.state.status === "success" && query.state.data?.state === "pending"
+				? 500
+				: false,
+	});
+}
+
+export function useCompleteTasteOnboarding(userId: number | undefined) {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (selections: TasteOnboardingSelection[]) =>
+			completeTasteOnboarding(selections),
+		onSuccess: () => {
+			queryClient.setQueryData<TasteOnboardingStateResponse>(
+				tasteOnboardingKey(userId),
+				{ state: "done" },
+			);
+			void queryClient.invalidateQueries({ queryKey: ["home"] });
+		},
 	});
 }

--- a/frontend/src/routes/Home.tsx
+++ b/frontend/src/routes/Home.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import { Link } from "react-router";
 import { Hero } from "../components/Hero";
 import { Rail } from "../components/Rail";
+import { TastePicker } from "../components/TastePicker";
 import type { MediaSummary } from "../lib/api";
 import { useMe } from "../lib/auth";
 import { AvailabilityContext, useAvailabilityMap } from "../lib/availability";
@@ -81,6 +82,7 @@ export function Home() {
 					</section>
 				)}
 				<Hero slides={home.data.hero} />
+				<TastePicker items={items} userId={me.data?.id} />
 				<div className="flex flex-col gap-8">
 					{home.data.rails.map((rail) => (
 						<Rail key={rail.id} rail={rail} />

--- a/frontend/src/routes/Login.test.tsx
+++ b/frontend/src/routes/Login.test.tsx
@@ -1,11 +1,16 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { ME_QUERY_KEY } from "../lib/auth";
 import { Login } from "./Login";
 
+beforeEach(() => {
+	vi.spyOn(window, "focus").mockImplementation(() => undefined);
+});
+
 afterEach(() => {
 	cleanup();
+	vi.restoreAllMocks();
 	vi.unstubAllGlobals();
 });
 
@@ -52,7 +57,21 @@ const USER = {
 	is_admin: false,
 };
 
-test("plex flow: opens approval url, keeps polling, then refreshes auth state", async () => {
+function fakeApprovalWindow(closed = false) {
+	const close = vi.fn();
+	const focus = vi.fn();
+	const replace = vi.fn();
+	const approval = {
+		closed,
+		close,
+		focus,
+		opener: window,
+		location: { replace },
+	} as unknown as Window;
+	return { approval, close, focus, replace };
+}
+
+test("plex flow protects and closes its approval window after polling succeeds", async () => {
 	let polls = 0;
 	stubFetch({
 		"POST /api/v1/auth/plex/pin": () => ({
@@ -69,18 +88,23 @@ test("plex flow: opens approval url, keeps polling, then refreshes auth state", 
 				: { status: 200, body: { status: "ok", user: USER } };
 		},
 	});
-	const open = vi.fn();
+	const { approval, close, focus, replace } = fakeApprovalWindow();
+	const open = vi.fn(() => approval);
 	vi.stubGlobal("open", open);
+	const parentFocus = vi.mocked(window.focus);
 	const invalidate = renderLogin();
 
 	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
 
 	await screen.findByText("Waiting for Plex approval…");
 	expect(open).toHaveBeenCalledWith(
-		"https://app.plex.tv/auth#?x",
-		"_blank",
-		"noopener",
+		"",
+		"tasterr-plex-auth",
+		"popup=yes,width=600,height=700,scrollbars=yes,resizable=yes",
 	);
+	expect(approval.opener).toBeNull();
+	expect(focus).toHaveBeenCalledOnce();
+	expect(replace).toHaveBeenCalledWith("https://app.plex.tv/auth#?x");
 	// First poll answers pending; the 2s refetch interval must fire again.
 	await vi.waitFor(() => expect(polls).toBeGreaterThanOrEqual(2), {
 		timeout: 5000,
@@ -90,6 +114,8 @@ test("plex flow: opens approval url, keeps polling, then refreshes auth state", 
 		() => expect(invalidate).toHaveBeenCalledWith({ queryKey: ME_QUERY_KEY }),
 		{ timeout: 5000 },
 	);
+	expect(close).toHaveBeenCalledOnce();
+	expect(parentFocus).toHaveBeenCalledOnce();
 }, 15000);
 
 test("plex flow: expired handle surfaces a retry message", async () => {
@@ -106,7 +132,11 @@ test("plex flow: expired handle surfaces a retry message", async () => {
 			body: { detail: "Unknown or expired sign-in attempt" },
 		}),
 	});
-	vi.stubGlobal("open", vi.fn());
+	const { approval, close } = fakeApprovalWindow();
+	vi.stubGlobal(
+		"open",
+		vi.fn(() => approval),
+	);
 	renderLogin();
 
 	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
@@ -118,6 +148,161 @@ test("plex flow: expired handle surfaces a retry message", async () => {
 	expect(
 		screen.getByRole("button", { name: "Sign in with Plex" }),
 	).toBeTruthy();
+	expect(close).toHaveBeenCalledOnce();
+});
+
+test("plex flow closes its blank window when PIN creation fails", async () => {
+	stubFetch({
+		"POST /api/v1/auth/plex/pin": () => ({ status: 503, body: {} }),
+	});
+	const { approval, close } = fakeApprovalWindow();
+	vi.stubGlobal(
+		"open",
+		vi.fn(() => approval),
+	);
+	renderLogin();
+
+	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
+
+	expect(
+		await screen.findByText("Could not reach Plex — try again."),
+	).toBeTruthy();
+	expect(close).toHaveBeenCalledOnce();
+});
+
+test("plex flow can complete when the approval window is blocked", async () => {
+	stubFetch({
+		"POST /api/v1/auth/plex/pin": () => ({
+			status: 200,
+			body: {
+				pin_id: "opaque-handle",
+				auth_url: "https://app.plex.tv/auth#?x",
+			},
+		}),
+		"POST /api/v1/auth/plex/pin/poll": () => ({
+			status: 200,
+			body: { status: "ok", user: USER },
+		}),
+	});
+	vi.stubGlobal(
+		"open",
+		vi.fn(() => null),
+	);
+	const invalidate = renderLogin();
+
+	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
+
+	await vi.waitFor(() =>
+		expect(invalidate).toHaveBeenCalledWith({ queryKey: ME_QUERY_KEY }),
+	);
+});
+
+test("plex flow reopens a protected approval window after popup blocking", async () => {
+	stubFetch({
+		"POST /api/v1/auth/plex/pin": () => ({
+			status: 200,
+			body: {
+				pin_id: "opaque-handle",
+				auth_url: "https://app.plex.tv/auth#?x",
+			},
+		}),
+		"POST /api/v1/auth/plex/pin/poll": () => ({
+			status: 200,
+			body: { status: "pending", user: null },
+		}),
+	});
+	const { approval, close, replace } = fakeApprovalWindow();
+	const open = vi
+		.fn<() => Window | null>()
+		.mockReturnValueOnce(null)
+		.mockReturnValueOnce(approval);
+	vi.stubGlobal("open", open);
+	renderLogin();
+
+	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
+	fireEvent.click(
+		await screen.findByRole("button", { name: "Reopen the approval page" }),
+	);
+
+	expect(open).toHaveBeenNthCalledWith(
+		2,
+		"",
+		"tasterr-plex-auth",
+		"popup=yes,width=600,height=700,scrollbars=yes,resizable=yes",
+	);
+	expect(approval.opener).toBeNull();
+	expect(replace).toHaveBeenCalledWith("https://app.plex.tv/auth#?x");
+	cleanup();
+	expect(close).toHaveBeenCalledOnce();
+});
+
+test("plex flow can complete after the user closes the approval window", async () => {
+	stubFetch({
+		"POST /api/v1/auth/plex/pin": () => ({
+			status: 200,
+			body: {
+				pin_id: "opaque-handle",
+				auth_url: "https://app.plex.tv/auth#?x",
+			},
+		}),
+		"POST /api/v1/auth/plex/pin/poll": () => ({
+			status: 200,
+			body: { status: "ok", user: USER },
+		}),
+	});
+	const { approval, close, replace } = fakeApprovalWindow(true);
+	vi.stubGlobal(
+		"open",
+		vi.fn(() => approval),
+	);
+	const invalidate = renderLogin();
+
+	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
+
+	await vi.waitFor(() =>
+		expect(invalidate).toHaveBeenCalledWith({ queryKey: ME_QUERY_KEY }),
+	);
+	expect(replace).not.toHaveBeenCalled();
+	expect(close).not.toHaveBeenCalled();
+});
+
+test("plex flow can complete when the browser severs the approval proxy", async () => {
+	stubFetch({
+		"POST /api/v1/auth/plex/pin": () => ({
+			status: 200,
+			body: {
+				pin_id: "opaque-handle",
+				auth_url: "https://app.plex.tv/auth#?x",
+			},
+		}),
+		"POST /api/v1/auth/plex/pin/poll": () => ({
+			status: 200,
+			body: { status: "ok", user: USER },
+		}),
+	});
+	const approval = {
+		get closed() {
+			throw new DOMException("WindowProxy severed");
+		},
+		set opener(_value: Window | null) {
+			throw new DOMException("WindowProxy severed");
+		},
+		close: vi.fn(),
+		focus: vi.fn(),
+		location: { replace: vi.fn() },
+	} as unknown as Window;
+	vi.stubGlobal(
+		"open",
+		vi.fn(() => approval),
+	);
+	const invalidate = renderLogin();
+
+	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
+
+	await vi.waitFor(() =>
+		expect(invalidate).toHaveBeenCalledWith({ queryKey: ME_QUERY_KEY }),
+	);
+	expect(approval.location.replace).not.toHaveBeenCalled();
 });
 
 test("local login posts credentials and refreshes auth state", async () => {

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -1,5 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { type FormEvent, useEffect, useState } from "react";
+import {
+	type FormEvent,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import { ApiError, createPlexPin, loginLocal, pollPlexPin } from "../lib/api";
 import { ME_QUERY_KEY } from "../lib/auth";
 
@@ -8,21 +14,67 @@ interface PendingPin {
 	authUrl: string;
 }
 
+const PLEX_POPUP_FEATURES =
+	"popup=yes,width=600,height=700,scrollbars=yes,resizable=yes";
+
 export function Login() {
 	const queryClient = useQueryClient();
 	const [pin, setPin] = useState<PendingPin | null>(null);
 	const [plexError, setPlexError] = useState<string | null>(null);
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
+	const approvalWindow = useRef<Window | null>(null);
+	const closeApprovalWindow = useCallback(() => {
+		const approval = approvalWindow.current;
+		approvalWindow.current = null;
+		try {
+			if (approval !== null && !approval.closed) approval.close();
+		} catch {
+			// Browser opener policies may sever a cross-origin WindowProxy.
+		}
+	}, []);
+
+	function navigateApprovalWindow(authUrl: string) {
+		const approval = approvalWindow.current;
+		try {
+			if (approval !== null && !approval.closed) {
+				approval.location.replace(authUrl);
+			}
+		} catch {
+			approvalWindow.current = null;
+		}
+	}
+
+	function openApprovalWindow(authUrl?: string) {
+		closeApprovalWindow();
+		const approval = window.open("", "tasterr-plex-auth", PLEX_POPUP_FEATURES);
+		if (approval === null) return;
+		approvalWindow.current = approval;
+		try {
+			approval.opener = null;
+		} catch {
+			closeApprovalWindow();
+			return;
+		}
+		try {
+			approval.focus();
+		} catch {
+			// Focus is progressive enhancement; polling remains authoritative.
+		}
+		if (authUrl !== undefined) navigateApprovalWindow(authUrl);
+	}
 
 	const startPlex = useMutation({
 		mutationFn: createPlexPin,
 		onSuccess: (created) => {
 			setPlexError(null);
 			setPin({ pinId: created.pin_id, authUrl: created.auth_url });
-			window.open(created.auth_url, "_blank", "noopener");
+			navigateApprovalWindow(created.auth_url);
 		},
-		onError: () => setPlexError("Could not reach Plex — try again."),
+		onError: () => {
+			closeApprovalWindow();
+			setPlexError("Could not reach Plex — try again.");
+		},
 	});
 
 	const poll = useQuery({
@@ -39,12 +91,19 @@ export function Login() {
 
 	useEffect(() => {
 		if (pollData?.status === "ok") {
+			closeApprovalWindow();
+			try {
+				window.focus();
+			} catch {
+				// Browsers may reject programmatic focus after cross-origin navigation.
+			}
 			void queryClient.invalidateQueries({ queryKey: ME_QUERY_KEY });
 		}
-	}, [pollData, queryClient]);
+	}, [pollData, queryClient, closeApprovalWindow]);
 
 	useEffect(() => {
 		if (pollError !== null) {
+			closeApprovalWindow();
 			setPlexError(
 				pollError instanceof ApiError && pollError.status === 404
 					? "Plex sign-in expired — try again."
@@ -52,7 +111,9 @@ export function Login() {
 			);
 			setPin(null);
 		}
-	}, [pollError]);
+	}, [pollError, closeApprovalWindow]);
+
+	useEffect(() => closeApprovalWindow, [closeApprovalWindow]);
 
 	const localLogin = useMutation({
 		mutationFn: (credentials: { email: string; password: string }) =>
@@ -84,7 +145,10 @@ export function Login() {
 				<div className="flex flex-col gap-2">
 					<button
 						type="button"
-						onClick={() => startPlex.mutate()}
+						onClick={() => {
+							openApprovalWindow();
+							startPlex.mutate();
+						}}
 						disabled={startPlex.isPending || pin !== null}
 						className="min-h-11 rounded bg-app-accent px-4 py-2 font-medium text-white transition-colors hover:brightness-110 focus-visible:outline-2 focus-visible:outline-app-text disabled:opacity-60"
 					>
@@ -93,14 +157,13 @@ export function Login() {
 					{pin !== null && (
 						<p className="text-sm text-app-subtle">
 							Approve the sign-in in the Plex window, then come back here.{" "}
-							<a
-								href={pin.authUrl}
-								target="_blank"
-								rel="noreferrer"
+							<button
+								type="button"
+								onClick={() => openApprovalWindow(pin.authUrl)}
 								className="underline"
 							>
 								Reopen the approval page
-							</a>
+							</button>
 						</p>
 					)}
 					{plexError !== null && (

--- a/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/design.md
+++ b/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/design.md
@@ -1,0 +1,101 @@
+## Context
+
+Availability currently reduces Seerr `mediaInfo` to status and seasons, even though Seerr already returns Plex web and custom-scheme links. A redacted read against the household Jellyseerr 3.4.1 instance confirmed `mediaUrl` and `iOSPlexUrl`; `plexUrl` was absent, as expected for Jellyseerr. No 4K record was present to exercise the optional 4K values, so recorded fixtures must cover both flavor aliases and all documented variants.
+
+The Android choice was resolved before design on a connected Samsung device running Android 16 with the current `com.plexapp.android` package. Android resolved and opened a real `plex://preplay/…` URI in Plex, while `https://app.plex.tv/desktop/` resolved to Chrome. Chrome's documented `intent://` contract supplies `S.browser_fallback_url` when the target package is absent.
+
+Follow-up LAN testing on Windows, Android, and iPadOS found that Plex Web and the installed mobile apps can discard the requested destination during sign-in or household-user selection and land on Plex Home. The web route sometimes succeeds on a later activation after Plex finishes initializing, while the native route consistently launched Plex but lost the destination in the tested clients. Tasterr cannot inspect or repair cross-origin Plex client navigation state without the prohibited Plex token/API scope, so the UX must preserve Tasterr for a user-driven web retry and label the handoffs honestly.
+
+Cold-start seeding runs asynchronously after login. The durable signal store already tells whether personalization has any input, while a process-local `seeding` set tells whether that answer is still pending. The Home response already contains enough varied titles to populate a small picker without another catalog endpoint.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Surface safe Seerr-provided playback links for fully or partially available regular and 4K library records across Overseerr and Jellyseerr.
+- Provide separate keyboard/remote-focusable Plex Web and Plex App controls so users can choose a recoverable browser path or attempt native handoff without a dead custom-scheme-only path.
+- Offer a one-time, non-blocking taste picker only after a user's cold-start seed has finished with no signals.
+- Reuse `watchlist` signals and the existing profile pipeline.
+
+**Non-Goals:**
+
+- Plex tokens, direct Plex HTTP, playback control, watch-history ingestion, or playback progress.
+- A new signal kind, recommendation weight, catalog, route-level onboarding wizard, or dependency.
+- Separate regular/4K buttons; one regular-first control is sufficient.
+
+## Decisions
+
+### 1. Normalize all Seerr aliases at the client boundary
+
+`SeerrMediaInfo` will accept `plexUrl` or `mediaUrl` as the regular web link, `iOSPlexUrl` as the regular app link, and the corresponding `plexUrl4k`/`mediaUrl4k` and `iOSPlexUrl4k` fields. It will also parse `status4k`. Pydantic alias choices keep the flavor difference inside `clients/seerr.py`; downstream code sees one vocabulary.
+
+Alternative: inspect the configured Seerr flavor. Rejected because the payload itself is sufficient and flavor detection adds a second contract.
+
+### 2. Availability owns validated, ready-to-use links
+
+The typed `Availability` model will contain an optional nested playback-link model for regular and 4K web, app, and Android-intent URLs. Normalization accepts web links only when they are credential-free HTTPS URLs on `app.plex.tv`, and app links only when they are fragment-free `plex://preplay/` URLs. Both link forms reject case-insensitive `X-Plex-Token` parameters before serialization. The Android intent is assembled server-side from those validated inputs with the fixed Plex package and a percent-encoded web fallback. Invalid or incomplete pairs are dropped.
+
+Availability status considers both `status` and `status4k`, preserving the highest Seerr fulfillment state. Playback links are retained only for a variant Seerr marks available or partially available. Batch availability uses the same secret-free model; this avoids a second near-identical response shape. Jellyseerr deployments backed by Jellyfin or Emby can emit `mediaUrl` links for their own host; the narrow `app.plex.tv` allowlist intentionally rejects those links and renders no Plex controls.
+
+Alternative: forward the raw strings and build the intent in React. Rejected because upstream JSON is untrusted and the frontend security contract requires external URLs to come from the BFF.
+
+### 3. Explicit Plex Web and Plex App controls, regular-first
+
+The detail modal resolves validated playback data without duplicating Seerr status rules, chooses the regular link set first, and falls back to 4K when regular is absent. It renders a Plex Web link for every resolved variant, plus a Plex App link when that variant has a validated platform target. The web link always uses HTTPS and opens in a new context with `noopener noreferrer`, preserving Tasterr so the user can retry after Plex finishes sign-in or household-user selection. On Android, the app link uses the prebuilt intent with its missing-app browser fallback; other platforms use Seerr's custom-scheme app URL without a timed navigation fallback. The controls carry a static experimental qualifier and participate naturally in the modal focus trap.
+
+Alternative: keep one platform-selected Play link or automatically retry the web target. Rejected after live testing because every tested Plex client can discard the requested title during household-user/PIN handling, and browser isolation prevents Tasterr from observing the result. A delayed retry can also replace Tasterr while an iOS app-confirmation prompt remains open. A dedicated dependency, redirect service, or Plex-aware authentication state would exceed this change's scope.
+
+### 4. Persist only whether onboarding was handled
+
+Alembic revision `0005` adds `users.taste_onboarding_seen`, non-null with a false default. Eligibility is derived rather than duplicated: `done` when the flag is true or signals exist, `pending` while the user's cold-start seed is reserved/running, and `show` otherwise. The seed reservation moves before task creation so a status request cannot observe an unscheduled gap; the existing background helper retains single-flight and cleanup behavior.
+
+Alternative: persist a multi-state onboarding/seed state machine. Rejected because signals plus the live seeding set already represent every state needed by one process.
+
+### 5. One read endpoint and one bounded mutation
+
+`GET /api/v1/taste-onboarding` returns `pending`, `show`, or `done` for the session user. `POST /api/v1/taste-onboarding` accepts at most 12 typed title keys within the application's bounded positive title-id range, records each as the existing idempotent `watchlist` signal, marks onboarding seen, commits once, and refreshes the profile once. Every browser-controlled mutation that can record a taste signal, including the direct signal and request endpoints, applies the same database-safe id bound. An empty selection is Skip. Both responses are explicit and secret-free.
+
+Alternative: call `POST /signals` once per selection and keep dismissal in browser storage. Rejected because it recomputes repeatedly and does not honor once-per-user behavior across devices.
+
+### 6. The picker is an inline Home section
+
+Home derives up to 12 unique candidates from the already-loaded hero and rails. The picker is a normal landmark with toggle buttons, a completion action, Clear picks, and Skip; it never traps focus, makes the browse shell inert, or delays Home. Selected title keys are retained independently of feed rerenders, while the same 12-title limit prevents newly presented candidates from extending the durable selection beyond the API bound. Visible selected titles remain removable, and Clear picks restores a choice path when every retained title has left the current candidate window. Submission failures are announced inline and leave browsing and the picker usable. The status query is keyed by session user and polls only after a successful `pending` response; if status fails or candidates are absent, the picker renders nothing and browsing remains intact.
+
+Alternative: an automatic modal or dedicated onboarding route. Rejected because either blocks browsing or adds navigation/state for a one-time optional prompt.
+
+### 7. The opener closes its Plex approval popup best-effort
+
+The Plex sign-in button opens an empty, sized popup synchronously from the user activation and retains only its transient `WindowProxy` in component memory. This follows Seerr's practical popup pattern so the Tasterr parent can remain active enough to run the existing PIN poll instead of becoming a background tab. Before navigating the popup to the backend-provided Plex approval URL, Tasterr sets the child context's `opener` to `null`; this prevents the cross-origin Plex page from navigating or scripting the Tasterr tab while the parent retains the limited handle needed for `close()`. The existing same-origin PIN poll remains the sole login-completion signal. On success, Tasterr closes the approval context when the browser still exposes it, requests focus for the Tasterr window, then refreshes auth state. API failure and component teardown also clean up a live blank/approval context.
+
+Popup blocking, manual closure, browser opener-policy isolation, or a mobile browser treating the requested popup as a normal tab must never block authentication. The PIN flow continues polling independently, and the existing reopen action creates and tracks another protected context. Auto-close and focus return are therefore progressive enhancements rather than conditions of successful login.
+
+Alternative: remove `noopener` and open Plex directly with an unrestricted opener, or add a Plex `forwardUrl` callback page. The unrestricted opener creates a reverse-tabnabbing capability, while a callback adds public-origin construction and another auth surface for behavior the existing poll already knows. Both are unnecessary.
+
+## Security considerations
+
+- **API endpoints:** both onboarding endpoints require the shared session dependency and explicit Pydantic response models. The POST uses the same-origin guard and shared authenticated mutation limiter, validates media type/id and a maximum list length, keys every write from the session user, and is added to the mutation inventory. The existing request mutation uses the same bounded browser-supplied title id before it can call Seerr or record a signal. Errors remain generic and no title selections are logged.
+- **Outbound HTTP:** only `clients/seerr.py` reads the extra upstream fields; the existing fixed settings-derived base URL, API-key read authentication, timeout, no-retry policy, and dropped unknown fields remain unchanged. No browser headers are forwarded and no Plex request is added.
+- **Frontend:** links are validated and assembled by the backend, which rejects token-bearing web and app targets before either can reach a browser response or Android intent. React renders accepted links as ordinary attributes, opens the web target with `noopener noreferrer`, suppresses the app target's outbound referrer, and renders all labels/title metadata and the plain-language experimental qualifier as text and as the controls' accessible description; there is no HTML injection or client-side secret/token storage. No timer, popup polling, or cross-origin state inspection is added. Plex sign-in retains only a transient `WindowProxy`, clears the child context's `opener` before cross-origin navigation, navigates only to the backend-provided approval URL, and treats popup, focus, or close failure as non-fatal. Onboarding failures render no blocking UI and are announced to assistive technology; the client retains at most the server's 12 allowed selections, and per-user query keys prevent another household user's cached onboarding state from being displayed.
+- **Database:** revision `0005` adds one non-secret boolean. SQLAlchemy expressions remain the only query/write path; no token or household title data is added to the user row or migration output.
+- **Secrets/privacy/logging:** Plex/Seerr tokens, cookies, internal URLs, raw upstream bodies, household link values, and selected title ids are not logged or checked into fixtures. Tests use invented URLs and ids. PublicConfig remains unchanged.
+- **Dependencies/build:** no dependency or lockfile change.
+
+## Risks / Trade-offs
+
+- [Seerr returns malformed or hostile link strings] → reject anything outside the narrow `app.plex.tv` HTTPS and `plex://preplay/` contracts; render no Play control.
+- [A Seerr flavor renames another optional field] → typed parsing drops it safely; unit fixtures plus the opt-in live contract expose contract drift.
+- [Android changes intent handling] → the web fallback remains embedded, and the behavior is isolated to one server-side builder plus a small user-agent selection.
+- [A Plex client drops the destination during sign-in or household-user/PIN handling] → the controls are explicitly experimental, and Plex Web opens separately so Tasterr remains available for a user-driven retry; repairing Plex client state would require out-of-scope Plex integration.
+- [A popup blocker, manual close, browser opener policy, or mobile tab behavior prevents automatic return] → PIN polling and login completion remain independent; the user may reopen or manually return, and auto-close/focus stays best-effort.
+- [A user opens Home before background seeding completes] → the reservation makes status `pending`; the picker polls without blocking the feed.
+- [Onboarding persistence succeeds but profile refresh fails] → watchlist signals are durable and the materialized profile self-heals on the next read.
+
+## Migration Plan
+
+1. Deploy revision `0005` before serving the new endpoints; existing users receive `taste_onboarding_seen = false`.
+2. Existing users with signals resolve directly to `done`; signal-less users become eligible after no seed is running.
+3. Rollback drops only the boolean. Picker-created watchlist signals remain valid user taste data and require no conversion.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/proposal.md
+++ b/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Tasterr can already tell when a title is in the household library, but it offers no direct path to play that title, and users whose Seerr request history is empty receive no useful cold-start personalization. These are the two deferred v1.x capabilities named in the founding blueprint and can now be added without Plex API access or a new recommendation signal vocabulary.
+
+## What Changes
+
+- Carry Seerr-provided Plex web and app deep links, including Overseerr/Jellyseerr aliases and 4K variants, through typed availability into title detail responses.
+- Show explicit, experimental Plex Web and Plex App controls for fully or partially available titles. Plex Web opens separately to preserve Tasterr for a retry when Plex discards a destination during sign-in or household-user selection; Android keeps its tested `intent://` missing-app fallback.
+- Make the existing Plex PIN approval flow use a real popup, close itself, and return focus to Tasterr on successful sign-in when the browser permits, without giving the Plex page access to the Tasterr tab or making popup success a login requirement.
+- Add a non-blocking, dismissible taste picker for users whose completed cold-start seed left them with no signals.
+- Record selected picker titles as the existing `watchlist` signal and persist dismissal/completion so the picker is not shown again.
+- Extend unit, API, frontend, generated-type, migration, and live Seerr contract coverage.
+
+## Capabilities
+
+### New Capabilities
+
+- `taste-onboarding`: Eligibility, presentation, dismissal, and signal recording for the one-time cold-start taste picker.
+
+### Modified Capabilities
+
+- `media-availability`: Fully or partially available-title normalization includes validated Seerr-provided Plex web/app links and their flavor aliases.
+- `media-browse`: The title detail modal offers experimental, accessible Plex Web and Plex App controls when a fully or partially available library title has usable links.
+- `taste-signals`: Browser-supplied title ids use the shared database-safe upper bound.
+- `media-requests`: Request title ids use the same bound before any Seerr or taste side effect.
+- `user-auth`: The SPA retains a protected, in-memory handle to its script-opened Plex approval window and closes it best-effort after the existing PIN poll succeeds.
+
+## Non-goals
+
+- Reading or exposing Plex tokens, calling the Plex API, ingesting Plex watch history, or starting playback directly.
+- Adding a new signal kind or changing recommendation weights/profile math.
+- Guaranteeing that Plex Web or a native Plex app preserves the requested destination through sign-in or household-user selection.
+- Building a separate onboarding catalog, onboarding route, or mandatory first-run flow.
+
+## Impact
+
+- Backend: Seerr wire models, availability domain/API models, title detail response, onboarding state/API, one additive SQLite migration, and security/boundary tests.
+- Frontend: generated OpenAPI types, detail Plex Web/App controls, a best-effort auto-closing Plex approval popup with focus return, and a home-feed taste picker using existing feed titles and signal semantics.
+- Systems: read-only Seerr integration only; no direct Plex traffic and no new dependency.
+- Milestone: advances the PRD's post-v1 Play-in-Plex and onboarding-picker scope.

--- a/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/specs/media-availability/spec.md
+++ b/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/specs/media-availability/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Availability carries validated Plex playback links
+
+Normalization SHALL carry a Seerr media variant's Plex web and app links in the
+typed, secret-free Availability model whenever its status is available or
+partially available. The client boundary SHALL accept both Overseerr's `plexUrl`
+and Jellyseerr's `mediaUrl`, plus
+`iOSPlexUrl`, and SHALL accept the corresponding `plexUrl4k`/`mediaUrl4k` and
+`iOSPlexUrl4k` variants. A web link SHALL be retained only when it is a
+credential-free HTTPS URL on `app.plex.tv`; an app link SHALL be retained only
+when it is a fragment-free `plex://preplay/` URL. Neither link form SHALL carry an
+`X-Plex-Token` parameter. The backend SHALL construct any Android intent URL from
+those validated inputs and include an encoded web fallback; the browser SHALL NOT
+assemble it.
+
+Jellyseerr deployments backed by Jellyfin or Emby can emit `mediaUrl` pointing at
+the configured Jellyfin or Emby host. The `app.plex.tv` allowlist SHALL reject that
+link, so no Plex playback control is expected for that deployment.
+
+#### Scenario: Overseerr aliases normalize
+
+- **WHEN** available `mediaInfo` contains `plexUrl` and `iOSPlexUrl`
+- **THEN** Availability contains the validated regular web/app links and an
+  Android intent with the web link as its browser fallback
+
+#### Scenario: Jellyseerr aliases normalize
+
+- **WHEN** available `mediaInfo` contains `mediaUrl` and `iOSPlexUrl`
+- **THEN** Availability contains the same downstream link shape as Overseerr
+
+#### Scenario: 4K-only title remains playable
+
+- **WHEN** `status4k` is available and only the 4K link aliases are populated
+- **THEN** Availability is available and carries the validated 4K playback links
+
+#### Scenario: Partially available media carries links
+
+- **WHEN** a regular or 4K media variant is partially available and supplies valid
+  playback links
+- **THEN** Availability retains that variant's validated playback links
+
+#### Scenario: Mixed regular and 4K states use highest fulfillment
+
+- **WHEN** regular and 4K variants report different fulfillment states
+- **THEN** Availability exposes the highest overall state and retains playback
+  links only for each variant independently marked available or partially available
+
+#### Scenario: Unsafe upstream link is dropped
+
+- **WHEN** Seerr supplies a web or app link outside the accepted
+  scheme/host/path or credential contract
+- **THEN** normalization omits that link and does not return it to the browser
+
+#### Scenario: Token-bearing playback link is dropped
+
+- **WHEN** a web or app link carries an `X-Plex-Token` parameter in any casing
+- **THEN** normalization rejects that link before it or a derived Android intent
+  can be serialized to the browser
+
+#### Scenario: Non-playable variant has no playback links
+
+- **WHEN** Seerr does not mark either regular or 4K media available or partially
+  available
+- **THEN** Availability carries no usable playback link even if stray link fields
+  were present upstream
+
+### Requirement: Live Seerr playback-link contract is opt-in
+
+The pytest-marked live Seerr suite SHALL validate the available-title link shape
+against an operator-supplied household title while printing only the Seerr version
+and generic outcomes. It SHALL NOT print URLs, title ids, or upstream bodies, and
+it SHALL remain excluded from `just check` and CI.
+
+#### Scenario: Live suite validates configured link aliases
+
+- **WHEN** the live suite runs with a Plex-backed available household title configured
+- **THEN** it confirms that typed media info exposes usable playback-link fields
+  without recording their values
+
+#### Scenario: Ordinary gate remains offline
+
+- **WHEN** `just check` runs
+- **THEN** no live playback-link contract executes

--- a/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/specs/media-browse/spec.md
+++ b/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/specs/media-browse/spec.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+### Requirement: Title detail exposes playable library links
+
+`GET /api/v1/title/{type}/{id}` SHALL surface the typed playback links resolved
+with library availability. When Seerr is unavailable, unconfigured, reports the
+title neither available nor partially available, or supplies no valid web link, the response SHALL contain no
+usable Play target and SHALL still return the TMDB detail normally. No Plex token,
+Seerr cookie, internal URL, or raw upstream body SHALL appear in the response.
+
+#### Scenario: Available title includes playback links
+
+- **WHEN** an authenticated client requests detail for an available title with
+  valid Seerr links
+- **THEN** its availability includes the server-validated web and platform link
+  targets
+
+#### Scenario: Seerr failure omits playback without failing detail
+
+- **WHEN** playback links cannot be resolved because Seerr is unavailable
+- **THEN** detail still returns with Unknown availability and no Play target
+
+#### Scenario: Non-playable title has no Play target
+
+- **WHEN** Seerr does not mark either title variant available or partially available
+- **THEN** detail includes its non-available status but no usable playback link
+
+### Requirement: Detail offers resilient Plex Web and Plex App controls
+
+The detail modal SHALL render a Plex Web link alongside the request affordance for
+an available or partially available title with a validated web target. When the chosen variant also
+has a validated app target, it SHALL separately render a Plex App link so the user
+chooses the destination instead of platform detection hiding the recoverable web path.
+On Android, the app link SHALL use the server-provided `intent://` target so Plex
+receives the tested `plex://preplay/` data and a missing app falls back to the web
+target. On other platforms, the app link SHALL use the validated custom scheme
+without scheduling a web fallback. The Plex Web link SHALL open in a new browsing
+context so Tasterr remains available for a user-driven retry. The regular variant
+SHALL be preferred over 4K, with 4K used when it is the only playable variant. The
+controls SHALL carry an explicit experimental qualifier and SHALL be reachable and activatable with the same
+keyboard/remote navigation and visible-focus behavior as adjacent detail controls.
+
+#### Scenario: Web remains an explicit choice on every platform
+
+- **WHEN** any user views an available title with a validated web target
+- **THEN** Plex Web is offered directly even when a Plex App target is also available
+
+#### Scenario: Plex Web preserves the browse session
+
+- **WHEN** a user activates Plex Web
+- **THEN** it opens in a new browsing context and leaves the Tasterr browse session
+  available for another activation
+
+#### Scenario: Partially available title remains playable
+
+- **WHEN** Seerr marks a regular or 4K variant partially available with a validated
+  web target
+- **THEN** the Plex Web and optional Plex App controls use that variant's links
+
+#### Scenario: Available Android title opens a fallback-capable intent
+
+- **WHEN** an Android user activates Plex App for an available title with app and web
+  links
+- **THEN** the selected href targets the Plex Android package and contains the
+  encoded web fallback supplied by the backend
+
+#### Scenario: Missing app target leaves the reliable web path
+
+- **WHEN** an available title has a web target but no validated app target
+- **THEN** Plex Web is rendered and Plex App is omitted
+
+#### Scenario: 4K is the only playable variant
+
+- **WHEN** regular media is unavailable and the 4K variant is available with a
+  valid web target
+- **THEN** the Plex Web and optional Plex App controls use the 4K link set
+
+#### Scenario: No usable link renders no control
+
+- **WHEN** Seerr is down, the title is neither available nor partially available,
+  or no valid web target exists
+- **THEN** no Plex playback control is rendered and the rest of detail remains operable
+
+#### Scenario: Playback controls disclose handoff reliability
+
+- **WHEN** either Plex playback control is rendered
+- **THEN** adjacent plain-language text identifies the handoff as experimental,
+  advises retrying Plex Web after sign-in or user switching, and warns that Plex
+  App may open Home instead of the title, including as the controls' accessible
+  description
+
+#### Scenario: Playback controls participate in modal navigation
+
+- **WHEN** keyboard or remote focus reaches either playback control
+- **THEN** it has visible focus, activates as a link, and remains inside the
+  detail modal's focus trap

--- a/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/specs/media-requests/spec.md
+++ b/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/specs/media-requests/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Request a title as the member
+
+`POST /api/v1/request` SHALL proxy `POST {SEERR_INTERNAL_URL}/api/v1/request`
+using the **per-user Seerr session cookie** stored on the member's Tasterr
+session row, so the request is attributed to that member in Seerr and subject to
+their own quota and approval rules. The request body SHALL be validated
+(`media_type` constrained to `movie` or `tv`, an integer `tmdb_id` between 1 and
+2,147,483,647 inclusive); a TV request SHALL request the whole series at the
+default quality. The global Seerr API key SHALL NOT be used for requests. On
+success the response SHALL carry the title's resulting library status so the SPA
+can update its badge, and the backend SHALL record a `request` taste signal for
+the member server-side — a failure to record the signal SHALL NOT fail the
+request response.
+
+#### Scenario: Request lands attributed to the member
+
+- **WHEN** an authenticated member requests a title
+- **THEN** the backend calls Seerr with that member's session cookie and Seerr
+  records the request as that member's
+
+#### Scenario: TV request covers the series
+
+- **WHEN** a member requests a TV title
+- **THEN** the request asks Seerr for the whole series at the default quality
+
+#### Scenario: Successful request returns the new status
+
+- **WHEN** Seerr accepts the request
+- **THEN** the response includes the title's resulting library status
+
+#### Scenario: Successful request records a taste signal
+
+- **WHEN** Seerr accepts a member's request
+- **THEN** a `request` signal for that title is recorded server-side for the member
+
+#### Scenario: Signal failure never fails the request
+
+- **WHEN** the taste-signal write errors after Seerr accepted the request
+- **THEN** the request response still reports success
+
+#### Scenario: Out-of-range title id rejected before request
+
+- **WHEN** a member submits a `tmdb_id` outside the supported range
+- **THEN** input validation rejects it before any Seerr or taste side effect

--- a/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/specs/taste-onboarding/spec.md
+++ b/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/specs/taste-onboarding/spec.md
@@ -1,0 +1,146 @@
+## ADDED Requirements
+
+### Requirement: Onboarding eligibility follows cold-start outcome
+
+`GET /api/v1/taste-onboarding` SHALL return `pending` while the authenticated
+user's cold-start seed is reserved or running, `show` after it is no longer
+running when the user has no signals and has never handled the picker, and `done`
+when the user has any signal or has previously completed/dismissed the picker.
+The endpoint SHALL use only the session user's server-side state and SHALL make no
+outbound request.
+
+#### Scenario: Seed is still running
+
+- **WHEN** a signal-less user's cold-start seed is reserved or running
+- **THEN** onboarding state is `pending`
+
+#### Scenario: Seed produced no signals
+
+- **WHEN** the seed is no longer running and the unseen user has no signals
+- **THEN** onboarding state is `show`
+
+#### Scenario: Seed produced signals
+
+- **WHEN** the user has one or more stored signals
+- **THEN** onboarding state is `done`
+
+#### Scenario: Unauthenticated eligibility read
+
+- **WHEN** a client without a valid session requests onboarding state
+- **THEN** the response is `401`
+
+### Requirement: Taste picker is optional and non-blocking
+
+When onboarding state is `show`, Home SHALL render a dismissible inline picker
+using up to 12 unique titles already present in the loaded Home feed. It SHALL NOT
+open a modal, trap focus, make the browse shell inert, delay Home, or prevent any
+normal browse action. Each title toggle and each completion/dismissal action SHALL
+be keyboard/remote focusable with visible state and focus. When state lookup fails
+or no candidate exists, the picker SHALL render nothing.
+
+#### Scenario: Eligible user sees inline choices
+
+- **WHEN** state is `show` and Home contains candidate titles
+- **THEN** the user sees title toggles plus completion and Skip controls without
+  losing access to the feed
+
+#### Scenario: Picker can be ignored
+
+- **WHEN** the eligible user continues navigating Home without acting on the
+  picker
+- **THEN** all normal browse content and controls remain operable
+
+#### Scenario: Status failure does not disturb browsing
+
+- **WHEN** onboarding state cannot be loaded
+- **THEN** polling stops and no picker or blocking error replaces the Home feed
+
+#### Scenario: Feed refresh preserves choices
+
+- **WHEN** Home candidates change after the user selects a title
+- **THEN** completion still submits that selected title key
+
+#### Scenario: Feed refresh cannot exceed the selection bound
+
+- **WHEN** retained choices reach 12 and Home presents different candidates
+- **THEN** new choices cannot be added until retained choices are removed or
+  cleared, completion never submits more than 12 titles, and clearing restores
+  the ability to choose from the current candidates
+
+#### Scenario: Completion failure is announced without blocking browse
+
+- **WHEN** saving selected titles fails
+- **THEN** the picker remains available, its generic error is announced, and the
+  rest of Home remains operable
+
+#### Scenario: Household account changes
+
+- **WHEN** the browser session changes from one household user to another
+- **THEN** the prior user's cached onboarding state is not rendered for the new
+  user
+
+### Requirement: Selections reuse watchlist signals
+
+`POST /api/v1/taste-onboarding` SHALL accept a validated list of at most 12 movie
+or TV title keys for the authenticated user. It SHALL record each selection using
+the existing idempotent `watchlist` signal, mark the user's picker handled, commit
+once, and run the existing best-effort profile refresh once. An empty list SHALL
+dismiss the picker without adding a signal. The endpoint SHALL add no signal kind
+or weight.
+
+#### Scenario: Selected likes become existing signals
+
+- **WHEN** a user completes the picker with selected titles
+- **THEN** each unique title has that user's existing `watchlist` signal and the
+  profile refresh is requested once
+
+#### Scenario: Skip records no taste
+
+- **WHEN** a user submits an empty selection
+- **THEN** the picker is marked handled and no signal is added
+
+#### Scenario: Duplicate submission is idempotent
+
+- **WHEN** the same selections are submitted more than once
+- **THEN** unique watchlist constraints prevent duplicate signals
+
+### Requirement: Picker completion persists per user
+
+Completion or dismissal SHALL be stored on the user's database row so the picker
+does not return in another session or browser. The flag SHALL contain no title,
+credential, token, or upstream data and SHALL remain unchanged by recommendation
+reset.
+
+#### Scenario: Dismissal survives a new session
+
+- **WHEN** a user dismisses the picker and later signs in from another browser
+- **THEN** onboarding state remains `done`
+
+#### Scenario: Reset does not repeat handled onboarding
+
+- **WHEN** a user who handled the picker resets recommendations
+- **THEN** the completion flag remains set and the picker is not shown again
+
+### Requirement: Onboarding mutation is hardened
+
+The onboarding POST SHALL require the shared session dependency, same-origin CSRF
+guard, and authenticated mutation rate limit; use explicit Pydantic input/output
+models; attribute state and signals only to the session user; return generic
+errors; and log no selected title ids or other household viewing behavior. A
+rate-limited or cross-origin request SHALL have no side effect.
+
+#### Scenario: Cross-origin submission is rejected
+
+- **WHEN** a browser submits onboarding from a cross-site origin
+- **THEN** it receives `403` before signals or completion state change
+
+#### Scenario: Rate-limited submission is rejected
+
+- **WHEN** the authenticated mutation bucket is exhausted
+- **THEN** it receives `429` before signals or completion state change
+
+#### Scenario: Invalid selection is rejected
+
+- **WHEN** a selection has an unsupported media type, non-positive id, an id
+  outside the supported title-id range, or the list exceeds its bound
+- **THEN** input validation rejects it before any database write

--- a/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/specs/taste-signals/spec.md
+++ b/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/specs/taste-signals/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: In-app interaction signals are recorded per user
+
+`POST /api/v1/signals` SHALL record an interaction signal for the authenticated
+user with a validated body: `media_type` constrained to `movie` or `tv`, an
+integer `tmdb_id` between 1 and 2,147,483,647 inclusive, and `kind` constrained
+to the client-recordable kinds — `detail_open`, `watchlist`, `not_interested`.
+Each stored signal SHALL carry its kind's fixed weight and a creation timestamp.
+Signals SHALL be scoped to the authenticated user only: a signal is attributed
+to the session user, and no endpoint SHALL expose one user's signals to another.
+
+#### Scenario: Detail open recorded
+
+- **WHEN** an authenticated user posts a `detail_open` signal for a title
+- **THEN** a signal row is stored for that user with the detail-open weight and
+  a timestamp
+
+#### Scenario: Unknown kind rejected
+
+- **WHEN** the posted `kind` is not one of the client-recordable kinds
+- **THEN** the request is rejected by input validation before anything is stored
+
+#### Scenario: Signals attributed to the session user
+
+- **WHEN** a signal is posted on a valid session
+- **THEN** it is stored against that session's user and no other
+
+#### Scenario: Out-of-range title id rejected
+
+- **WHEN** the posted `tmdb_id` is outside the supported range
+- **THEN** input validation rejects it before any signal or profile side effect

--- a/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/specs/user-auth/spec.md
+++ b/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/specs/user-auth/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: SPA login experience
+
+The login screen SHALL offer both paths: "Sign in with Plex" and a local
+email/password form. Plex sign-in SHALL open a script-created popup context
+directly from the user's activation, sever that context's access to its opener
+before navigating to the backend-provided Plex approval URL, and retain only an
+in-memory handle for best-effort cleanup. The SPA SHALL poll until completion and,
+when the browser still exposes the script-created context, close it and request
+focus for Tasterr after success.
+A blocked, manually closed, or browser-severed context SHALL NOT block polling or
+successful login, and the user SHALL be able to reopen a new protected approval
+context. On success the SPA SHALL switch to the authenticated state without a full
+reload; a logout control SHALL end the session and return to the login screen.
+Failures SHALL surface as generic, human-readable messages.
+
+#### Scenario: Plex login from the SPA
+
+- **WHEN** the user starts Plex login, approves on plex.tv, and the browser retains
+  the script-created context handle
+- **THEN** the SPA detects completion via polling, closes that context, requests
+  focus for Tasterr, and shows the authenticated app
+
+#### Scenario: Plex approval cannot control Tasterr
+
+- **WHEN** Tasterr navigates its script-created context to the Plex approval URL
+- **THEN** the child context has no `opener` reference to the Tasterr tab
+
+#### Scenario: Approval context is unavailable
+
+- **WHEN** a popup blocker, manual close, or browser opener policy makes the
+  approval context unavailable
+- **THEN** polling and successful login remain operable, and the reopen action can
+  create and track a replacement context
+
+#### Scenario: Local login from the SPA
+
+- **WHEN** the user submits email and password accepted by Seerr
+- **THEN** the SPA shows the authenticated app
+
+#### Scenario: Logout from the SPA
+
+- **WHEN** the user activates logout
+- **THEN** the SPA returns to the login screen and the session is revoked

--- a/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/tasks.md
+++ b/openspec/changes/archive/2026-08-22-add-plex-play-and-taste-onboarding/tasks.md
@@ -1,0 +1,78 @@
+## 1. Plex Playback Links
+
+- [x] 1.1 Extend `SeerrMediaInfo` with regular/4K status and Overseerr/Jellyseerr playback-link aliases, with recorded client fixtures for both flavors and unknown-field tolerance.
+- [x] 1.2 Normalize available playback variants into validated web/app/Android-intent links, preserve Seerr-down degradation, and cover status, unsafe URL, API serialization, PublicConfig/boundary, and opt-in live-contract behavior.
+- [x] 1.3 Add the initial accessible detail-modal Play control with regular-first/4K fallback and platform selection, covered by frontend rendering, href, absent-link, and focus tests (superseded by 9.2 and 10.2).
+
+## 2. Onboarding State and API
+
+- [x] 2.1 Add Alembic revision `0005` and the `User.taste_onboarding_seen` model field, covering fresh upgrade, existing-row default, rollback, and schema consistency.
+- [x] 2.2 Reserve cold-start seeding before task dispatch so onboarding can distinguish pending from empty while preserving single-flight, failure cleanup, and non-blocking login tests.
+- [x] 2.3 Add session-scoped onboarding status/submission endpoints that persist dismissal and batch existing `watchlist` signals with one profile refresh, covering validation, idempotence, CSRF, rate limiting, privacy, and mutation inventory.
+
+## 3. Onboarding Home Experience
+
+- [x] 3.1 Add generated-client wrappers/hooks and an inline Home taste picker using unique existing feed titles, with tests for pending polling, selection, Skip, persistence success, accessibility, and invisible failure/empty states.
+
+## 4. Contracts
+
+- [x] 4.1 Regenerate OpenAPI and frontend API types in the devcontainer and verify the committed schema contains only the intended secret-free fields.
+- [x] 4.2 Run strict OpenSpec validation and fix every change-artifact issue.
+
+## 5. Quality Gate
+
+- [x] 5.1 Run `just check` inside the devcontainer and fix every backend/frontend failure.
+
+## 6. Review Remediation
+
+- [x] 6.1 Harden the initial playback-link edge cases by rejecting trailing fragments, suppressing the referrer, and covering mixed regular/4K fulfillment (the app fallback behavior was superseded by 10.2).
+- [x] 6.2 Keep onboarding polling tied to successful pending responses, scope cached state to the signed-in user, and preserve selected title payloads across feed refreshes.
+- [x] 6.3 Bound onboarding and direct signal TMDB ids to a database-safe integer range with endpoint regression tests.
+- [x] 6.4 Regenerate contracts, run strict OpenSpec validation, and pass `just check` in the devcontainer.
+
+## 7. Second Review Remediation
+
+- [x] 7.1 Enforce the 12-title picker bound across feed refreshes and announce submission failures, with frontend regression coverage.
+- [x] 7.2 Apply the shared database-safe TMDB id bound to the existing request mutation and cover rejection before any upstream or taste side effect.
+- [x] 7.3 Regenerate contracts, run strict OpenSpec validation, and pass `just check` in the devcontainer.
+
+## 8. Final Review Remediation
+
+- [x] 8.1 Add an accessible Clear picks recovery path when retained selections leave the current feed window, and extend the cap regression through recovery and submission.
+- [x] 8.2 Declare and specify the shared title-id bound in the modified `taste-signals` and `media-requests` capabilities.
+- [x] 8.3 Run strict OpenSpec validation and pass `just check` in the devcontainer.
+
+## 9. Live Device Remediation
+
+- [x] 9.1 Record the household-user/PIN handoff limitation and specify separate Plex Web and Plex App controls with safe fallbacks.
+- [x] 9.2 Implement the two accessible playback controls across desktop, Android, and iOS/iPadOS behavior, with focused frontend regression coverage.
+- [x] 9.3 Run strict OpenSpec validation, pass `just check` in the devcontainer, and rebuild the isolated LAN test stack.
+
+## 10. Handoff Reliability Remediation
+
+- [x] 10.1 Update the proposal, design, and playback specs for partial-library playback, new-tab Plex Web recovery, removal of the timed app fallback, explicit experimental labeling, and the Jellyfin/Emby link limitation.
+- [x] 10.2 Implement the backend and frontend handoff changes with focused partial-status, link-attribute, rendering, and absent/invalid-link regression coverage.
+- [x] 10.3 Run strict OpenSpec validation and pass `just check` in the devcontainer.
+
+## 11. Final Plex UX Remediation
+
+- [x] 11.1 Specify plain-language experimental handoff guidance and a secure, best-effort auto-closing Plex approval window, including blocked, closed, and browser-severed fallbacks.
+- [x] 11.2 Implement the handoff copy and approval-window lifecycle with focused frontend success, reopen, popup-blocked, manual-close, and failure coverage.
+- [x] 11.3 Run strict OpenSpec validation, pass `just check` in the devcontainer, and rebuild and verify the isolated LAN test stack.
+
+## 12. Pre-archive Review and Popup Return Remediation
+
+- [x] 12.1 Reconcile the playback deltas with partial availability and the pinned OpenSpec parser, correct stale task prose, and specify accessible playback guidance plus best-effort popup focus return.
+- [x] 12.2 Implement a protected sized Plex popup with severed-context recovery and focus return, reject Plex-token-bearing web URLs, align and describe playback controls, and make live playback checks portable and non-disclosing.
+- [x] 12.3 Run focused regressions, pinned strict OpenSpec validation, `just check`, and rebuild and verify the isolated LAN test stack.
+
+## 13. Final Security Review Remediation
+
+- [x] 13.1 Specify symmetric token-parameter rejection for Plex web and app links and make the credential-rejection scenario archive-visible.
+- [x] 13.2 Reject token-bearing app links before intent construction and pin app-link rejection, regular-over-4K selection, and failed-popup-disown behavior with focused regressions.
+- [x] 13.3 Run focused regressions, pinned strict OpenSpec validation, `just check`, and rebuild and verify the isolated LAN test stack.
+
+## 14. Pre-archive Regression Hardening
+
+- [x] 14.1 Pin percent-encoded token names, whitespace padding, and non-default or malformed web ports in the playback-link rejection matrix.
+- [x] 14.2 Run the focused regression, pinned strict OpenSpec validation, and `just check` in the devcontainer.

--- a/openspec/specs/media-availability/spec.md
+++ b/openspec/specs/media-availability/spec.md
@@ -129,3 +129,86 @@ Seerr version tested.
 - **THEN** no live-marked availability test executes and no network access is
   attempted
 
+### Requirement: Availability carries validated Plex playback links
+
+Normalization SHALL carry a Seerr media variant's Plex web and app links in the
+typed, secret-free Availability model whenever its status is available or
+partially available. The client boundary SHALL accept both Overseerr's `plexUrl`
+and Jellyseerr's `mediaUrl`, plus
+`iOSPlexUrl`, and SHALL accept the corresponding `plexUrl4k`/`mediaUrl4k` and
+`iOSPlexUrl4k` variants. A web link SHALL be retained only when it is a
+credential-free HTTPS URL on `app.plex.tv`; an app link SHALL be retained only
+when it is a fragment-free `plex://preplay/` URL. Neither link form SHALL carry an
+`X-Plex-Token` parameter. The backend SHALL construct any Android intent URL from
+those validated inputs and include an encoded web fallback; the browser SHALL NOT
+assemble it.
+
+Jellyseerr deployments backed by Jellyfin or Emby can emit `mediaUrl` pointing at
+the configured Jellyfin or Emby host. The `app.plex.tv` allowlist SHALL reject that
+link, so no Plex playback control is expected for that deployment.
+
+#### Scenario: Overseerr aliases normalize
+
+- **WHEN** available `mediaInfo` contains `plexUrl` and `iOSPlexUrl`
+- **THEN** Availability contains the validated regular web/app links and an
+  Android intent with the web link as its browser fallback
+
+#### Scenario: Jellyseerr aliases normalize
+
+- **WHEN** available `mediaInfo` contains `mediaUrl` and `iOSPlexUrl`
+- **THEN** Availability contains the same downstream link shape as Overseerr
+
+#### Scenario: 4K-only title remains playable
+
+- **WHEN** `status4k` is available and only the 4K link aliases are populated
+- **THEN** Availability is available and carries the validated 4K playback links
+
+#### Scenario: Partially available media carries links
+
+- **WHEN** a regular or 4K media variant is partially available and supplies valid
+  playback links
+- **THEN** Availability retains that variant's validated playback links
+
+#### Scenario: Mixed regular and 4K states use highest fulfillment
+
+- **WHEN** regular and 4K variants report different fulfillment states
+- **THEN** Availability exposes the highest overall state and retains playback
+  links only for each variant independently marked available or partially available
+
+#### Scenario: Unsafe upstream link is dropped
+
+- **WHEN** Seerr supplies a web or app link outside the accepted
+  scheme/host/path or credential contract
+- **THEN** normalization omits that link and does not return it to the browser
+
+#### Scenario: Token-bearing playback link is dropped
+
+- **WHEN** a web or app link carries an `X-Plex-Token` parameter in any casing
+- **THEN** normalization rejects that link before it or a derived Android intent
+  can be serialized to the browser
+
+#### Scenario: Non-playable variant has no playback links
+
+- **WHEN** Seerr does not mark either regular or 4K media available or partially
+  available
+- **THEN** Availability carries no usable playback link even if stray link fields
+  were present upstream
+
+### Requirement: Live Seerr playback-link contract is opt-in
+
+The pytest-marked live Seerr suite SHALL validate the available-title link shape
+against an operator-supplied household title while printing only the Seerr version
+and generic outcomes. It SHALL NOT print URLs, title ids, or upstream bodies, and
+it SHALL remain excluded from `just check` and CI.
+
+#### Scenario: Live suite validates configured link aliases
+
+- **WHEN** the live suite runs with a Plex-backed available household title configured
+- **THEN** it confirms that typed media info exposes usable playback-link fields
+  without recording their values
+
+#### Scenario: Ordinary gate remains offline
+
+- **WHEN** `just check` runs
+- **THEN** no live playback-link contract executes
+

--- a/openspec/specs/media-browse/spec.md
+++ b/openspec/specs/media-browse/spec.md
@@ -2,9 +2,7 @@
 
 ## Purpose
 TBD - created by archiving change m2-browse. Update Purpose after archive.
-
 ## Requirements
-
 ### Requirement: Home feed of a hero and composed rails
 
 `GET /api/v1/home` SHALL return the enabled hero section and an ordered list of
@@ -384,3 +382,98 @@ browsing context without granting the destination access to the opener.
 
 - **WHEN** the user activates the TMDB link in a detail view
 - **THEN** it opens in a separate browsing context with opener access disabled
+
+### Requirement: Title detail exposes playable library links
+
+`GET /api/v1/title/{type}/{id}` SHALL surface the typed playback links resolved
+with library availability. When Seerr is unavailable, unconfigured, reports the
+title neither available nor partially available, or supplies no valid web link, the response SHALL contain no
+usable Play target and SHALL still return the TMDB detail normally. No Plex token,
+Seerr cookie, internal URL, or raw upstream body SHALL appear in the response.
+
+#### Scenario: Available title includes playback links
+
+- **WHEN** an authenticated client requests detail for an available title with
+  valid Seerr links
+- **THEN** its availability includes the server-validated web and platform link
+  targets
+
+#### Scenario: Seerr failure omits playback without failing detail
+
+- **WHEN** playback links cannot be resolved because Seerr is unavailable
+- **THEN** detail still returns with Unknown availability and no Play target
+
+#### Scenario: Non-playable title has no Play target
+
+- **WHEN** Seerr does not mark either title variant available or partially available
+- **THEN** detail includes its non-available status but no usable playback link
+
+### Requirement: Detail offers resilient Plex Web and Plex App controls
+
+The detail modal SHALL render a Plex Web link alongside the request affordance for
+an available or partially available title with a validated web target. When the chosen variant also
+has a validated app target, it SHALL separately render a Plex App link so the user
+chooses the destination instead of platform detection hiding the recoverable web path.
+On Android, the app link SHALL use the server-provided `intent://` target so Plex
+receives the tested `plex://preplay/` data and a missing app falls back to the web
+target. On other platforms, the app link SHALL use the validated custom scheme
+without scheduling a web fallback. The Plex Web link SHALL open in a new browsing
+context so Tasterr remains available for a user-driven retry. The regular variant
+SHALL be preferred over 4K, with 4K used when it is the only playable variant. The
+controls SHALL carry an explicit experimental qualifier and SHALL be reachable and activatable with the same
+keyboard/remote navigation and visible-focus behavior as adjacent detail controls.
+
+#### Scenario: Web remains an explicit choice on every platform
+
+- **WHEN** any user views an available title with a validated web target
+- **THEN** Plex Web is offered directly even when a Plex App target is also available
+
+#### Scenario: Plex Web preserves the browse session
+
+- **WHEN** a user activates Plex Web
+- **THEN** it opens in a new browsing context and leaves the Tasterr browse session
+  available for another activation
+
+#### Scenario: Partially available title remains playable
+
+- **WHEN** Seerr marks a regular or 4K variant partially available with a validated
+  web target
+- **THEN** the Plex Web and optional Plex App controls use that variant's links
+
+#### Scenario: Available Android title opens a fallback-capable intent
+
+- **WHEN** an Android user activates Plex App for an available title with app and web
+  links
+- **THEN** the selected href targets the Plex Android package and contains the
+  encoded web fallback supplied by the backend
+
+#### Scenario: Missing app target leaves the reliable web path
+
+- **WHEN** an available title has a web target but no validated app target
+- **THEN** Plex Web is rendered and Plex App is omitted
+
+#### Scenario: 4K is the only playable variant
+
+- **WHEN** regular media is unavailable and the 4K variant is available with a
+  valid web target
+- **THEN** the Plex Web and optional Plex App controls use the 4K link set
+
+#### Scenario: No usable link renders no control
+
+- **WHEN** Seerr is down, the title is neither available nor partially available,
+  or no valid web target exists
+- **THEN** no Plex playback control is rendered and the rest of detail remains operable
+
+#### Scenario: Playback controls disclose handoff reliability
+
+- **WHEN** either Plex playback control is rendered
+- **THEN** adjacent plain-language text identifies the handoff as experimental,
+  advises retrying Plex Web after sign-in or user switching, and warns that Plex
+  App may open Home instead of the title, including as the controls' accessible
+  description
+
+#### Scenario: Playback controls participate in modal navigation
+
+- **WHEN** keyboard or remote focus reaches either playback control
+- **THEN** it has visible focus, activates as a link, and remains inside the
+  detail modal's focus trap

--- a/openspec/specs/media-requests/spec.md
+++ b/openspec/specs/media-requests/spec.md
@@ -5,16 +5,17 @@ TBD - created by archiving change m3-seerr. Update Purpose after archive.
 ## Requirements
 ### Requirement: Request a title as the member
 
-`POST /api/v1/request` SHALL proxy `POST {SEERR_INTERNAL_URL}/api/v1/request` using
-the **per-user Seerr session cookie** stored on the member's Tasterr session row,
-so the request is attributed to that member in Seerr and subject to their own quota
-and approval rules. The request body SHALL be validated (`media_type` constrained
-to `movie` or `tv`, a positive integer `tmdb_id`); a TV request SHALL request the
-whole series at the default quality. The global Seerr API key SHALL NOT be used for
-requests. On success the response SHALL carry the title's resulting library status
-so the SPA can update its badge, and the backend SHALL record a `request` taste
-signal for the member server-side — a failure to record the signal SHALL NOT fail
-the request response.
+`POST /api/v1/request` SHALL proxy `POST {SEERR_INTERNAL_URL}/api/v1/request`
+using the **per-user Seerr session cookie** stored on the member's Tasterr
+session row, so the request is attributed to that member in Seerr and subject to
+their own quota and approval rules. The request body SHALL be validated
+(`media_type` constrained to `movie` or `tv`, an integer `tmdb_id` between 1 and
+2,147,483,647 inclusive); a TV request SHALL request the whole series at the
+default quality. The global Seerr API key SHALL NOT be used for requests. On
+success the response SHALL carry the title's resulting library status so the SPA
+can update its badge, and the backend SHALL record a `request` taste signal for
+the member server-side — a failure to record the signal SHALL NOT fail the
+request response.
 
 #### Scenario: Request lands attributed to the member
 
@@ -41,6 +42,11 @@ the request response.
 
 - **WHEN** the taste-signal write errors after Seerr accepted the request
 - **THEN** the request response still reports success
+
+#### Scenario: Out-of-range title id rejected before request
+
+- **WHEN** a member submits a `tmdb_id` outside the supported range
+- **THEN** input validation rejects it before any Seerr or taste side effect
 
 ### Requirement: Invalid-session re-auth ladder
 

--- a/openspec/specs/taste-onboarding/spec.md
+++ b/openspec/specs/taste-onboarding/spec.md
@@ -1,0 +1,149 @@
+# taste-onboarding Specification
+
+## Purpose
+TBD - created by archiving change add-plex-play-and-taste-onboarding. Update Purpose after archive.
+## Requirements
+### Requirement: Onboarding eligibility follows cold-start outcome
+
+`GET /api/v1/taste-onboarding` SHALL return `pending` while the authenticated
+user's cold-start seed is reserved or running, `show` after it is no longer
+running when the user has no signals and has never handled the picker, and `done`
+when the user has any signal or has previously completed/dismissed the picker.
+The endpoint SHALL use only the session user's server-side state and SHALL make no
+outbound request.
+
+#### Scenario: Seed is still running
+
+- **WHEN** a signal-less user's cold-start seed is reserved or running
+- **THEN** onboarding state is `pending`
+
+#### Scenario: Seed produced no signals
+
+- **WHEN** the seed is no longer running and the unseen user has no signals
+- **THEN** onboarding state is `show`
+
+#### Scenario: Seed produced signals
+
+- **WHEN** the user has one or more stored signals
+- **THEN** onboarding state is `done`
+
+#### Scenario: Unauthenticated eligibility read
+
+- **WHEN** a client without a valid session requests onboarding state
+- **THEN** the response is `401`
+
+### Requirement: Taste picker is optional and non-blocking
+
+When onboarding state is `show`, Home SHALL render a dismissible inline picker
+using up to 12 unique titles already present in the loaded Home feed. It SHALL NOT
+open a modal, trap focus, make the browse shell inert, delay Home, or prevent any
+normal browse action. Each title toggle and each completion/dismissal action SHALL
+be keyboard/remote focusable with visible state and focus. When state lookup fails
+or no candidate exists, the picker SHALL render nothing.
+
+#### Scenario: Eligible user sees inline choices
+
+- **WHEN** state is `show` and Home contains candidate titles
+- **THEN** the user sees title toggles plus completion and Skip controls without
+  losing access to the feed
+
+#### Scenario: Picker can be ignored
+
+- **WHEN** the eligible user continues navigating Home without acting on the
+  picker
+- **THEN** all normal browse content and controls remain operable
+
+#### Scenario: Status failure does not disturb browsing
+
+- **WHEN** onboarding state cannot be loaded
+- **THEN** polling stops and no picker or blocking error replaces the Home feed
+
+#### Scenario: Feed refresh preserves choices
+
+- **WHEN** Home candidates change after the user selects a title
+- **THEN** completion still submits that selected title key
+
+#### Scenario: Feed refresh cannot exceed the selection bound
+
+- **WHEN** retained choices reach 12 and Home presents different candidates
+- **THEN** new choices cannot be added until retained choices are removed or
+  cleared, completion never submits more than 12 titles, and clearing restores
+  the ability to choose from the current candidates
+
+#### Scenario: Completion failure is announced without blocking browse
+
+- **WHEN** saving selected titles fails
+- **THEN** the picker remains available, its generic error is announced, and the
+  rest of Home remains operable
+
+#### Scenario: Household account changes
+
+- **WHEN** the browser session changes from one household user to another
+- **THEN** the prior user's cached onboarding state is not rendered for the new
+  user
+
+### Requirement: Selections reuse watchlist signals
+
+`POST /api/v1/taste-onboarding` SHALL accept a validated list of at most 12 movie
+or TV title keys for the authenticated user. It SHALL record each selection using
+the existing idempotent `watchlist` signal, mark the user's picker handled, commit
+once, and run the existing best-effort profile refresh once. An empty list SHALL
+dismiss the picker without adding a signal. The endpoint SHALL add no signal kind
+or weight.
+
+#### Scenario: Selected likes become existing signals
+
+- **WHEN** a user completes the picker with selected titles
+- **THEN** each unique title has that user's existing `watchlist` signal and the
+  profile refresh is requested once
+
+#### Scenario: Skip records no taste
+
+- **WHEN** a user submits an empty selection
+- **THEN** the picker is marked handled and no signal is added
+
+#### Scenario: Duplicate submission is idempotent
+
+- **WHEN** the same selections are submitted more than once
+- **THEN** unique watchlist constraints prevent duplicate signals
+
+### Requirement: Picker completion persists per user
+
+Completion or dismissal SHALL be stored on the user's database row so the picker
+does not return in another session or browser. The flag SHALL contain no title,
+credential, token, or upstream data and SHALL remain unchanged by recommendation
+reset.
+
+#### Scenario: Dismissal survives a new session
+
+- **WHEN** a user dismisses the picker and later signs in from another browser
+- **THEN** onboarding state remains `done`
+
+#### Scenario: Reset does not repeat handled onboarding
+
+- **WHEN** a user who handled the picker resets recommendations
+- **THEN** the completion flag remains set and the picker is not shown again
+
+### Requirement: Onboarding mutation is hardened
+
+The onboarding POST SHALL require the shared session dependency, same-origin CSRF
+guard, and authenticated mutation rate limit; use explicit Pydantic input/output
+models; attribute state and signals only to the session user; return generic
+errors; and log no selected title ids or other household viewing behavior. A
+rate-limited or cross-origin request SHALL have no side effect.
+
+#### Scenario: Cross-origin submission is rejected
+
+- **WHEN** a browser submits onboarding from a cross-site origin
+- **THEN** it receives `403` before signals or completion state change
+
+#### Scenario: Rate-limited submission is rejected
+
+- **WHEN** the authenticated mutation bucket is exhausted
+- **THEN** it receives `429` before signals or completion state change
+
+#### Scenario: Invalid selection is rejected
+
+- **WHEN** a selection has an unsupported media type, non-positive id, an id
+  outside the supported title-id range, or the list exceeds its bound
+- **THEN** input validation rejects it before any database write

--- a/openspec/specs/taste-signals/spec.md
+++ b/openspec/specs/taste-signals/spec.md
@@ -6,12 +6,12 @@ TBD - created by archiving change m4-taste. Update Purpose after archive.
 ### Requirement: In-app interaction signals are recorded per user
 
 `POST /api/v1/signals` SHALL record an interaction signal for the authenticated
-user with a validated body: `media_type` constrained to `movie` or `tv`, a
-positive integer `tmdb_id`, and `kind` constrained to the client-recordable
-kinds — `detail_open`, `watchlist`, `not_interested`. Each stored signal SHALL
-carry its kind's fixed weight and a creation timestamp. Signals SHALL be scoped
-to the authenticated user only: a signal is attributed to the session user, and
-no endpoint SHALL expose one user's signals to another.
+user with a validated body: `media_type` constrained to `movie` or `tv`, an
+integer `tmdb_id` between 1 and 2,147,483,647 inclusive, and `kind` constrained
+to the client-recordable kinds — `detail_open`, `watchlist`, `not_interested`.
+Each stored signal SHALL carry its kind's fixed weight and a creation timestamp.
+Signals SHALL be scoped to the authenticated user only: a signal is attributed
+to the session user, and no endpoint SHALL expose one user's signals to another.
 
 #### Scenario: Detail open recorded
 
@@ -28,6 +28,11 @@ no endpoint SHALL expose one user's signals to another.
 
 - **WHEN** a signal is posted on a valid session
 - **THEN** it is stored against that session's user and no other
+
+#### Scenario: Out-of-range title id rejected
+
+- **WHEN** the posted `tmdb_id` is outside the supported range
+- **THEN** input validation rejects it before any signal or profile side effect
 
 ### Requirement: Server-recorded kinds are not accepted from the client
 

--- a/openspec/specs/user-auth/spec.md
+++ b/openspec/specs/user-auth/spec.md
@@ -191,21 +191,46 @@ browser headers upstream or upstream headers/bodies downstream.
   error, never the raw upstream body
 
 ### Requirement: SPA login experience
-The login screen SHALL offer both paths: "Sign in with Plex" (opens the approval
-URL and polls until completion) and a local email/password form. On success the
-SPA switches to the authenticated state without a full reload; a logout control
-ends the session and returns to the login screen. Failures surface as generic,
-human-readable messages.
+
+The login screen SHALL offer both paths: "Sign in with Plex" and a local
+email/password form. Plex sign-in SHALL open a script-created popup context
+directly from the user's activation, sever that context's access to its opener
+before navigating to the backend-provided Plex approval URL, and retain only an
+in-memory handle for best-effort cleanup. The SPA SHALL poll until completion and,
+when the browser still exposes the script-created context, close it and request
+focus for Tasterr after success.
+A blocked, manually closed, or browser-severed context SHALL NOT block polling or
+successful login, and the user SHALL be able to reopen a new protected approval
+context. On success the SPA SHALL switch to the authenticated state without a full
+reload; a logout control SHALL end the session and return to the login screen.
+Failures SHALL surface as generic, human-readable messages.
 
 #### Scenario: Plex login from the SPA
-- **WHEN** the user clicks "Sign in with Plex" and approves on plex.tv
-- **THEN** the SPA detects completion via polling and shows the authenticated app
+
+- **WHEN** the user starts Plex login, approves on plex.tv, and the browser retains
+  the script-created context handle
+- **THEN** the SPA detects completion via polling, closes that context, requests
+  focus for Tasterr, and shows the authenticated app
+
+#### Scenario: Plex approval cannot control Tasterr
+
+- **WHEN** Tasterr navigates its script-created context to the Plex approval URL
+- **THEN** the child context has no `opener` reference to the Tasterr tab
+
+#### Scenario: Approval context is unavailable
+
+- **WHEN** a popup blocker, manual close, or browser opener policy makes the
+  approval context unavailable
+- **THEN** polling and successful login remain operable, and the reopen action can
+  create and track a replacement context
 
 #### Scenario: Local login from the SPA
+
 - **WHEN** the user submits email and password accepted by Seerr
 - **THEN** the SPA shows the authenticated app
 
 #### Scenario: Logout from the SPA
+
 - **WHEN** the user activates logout
 - **THEN** the SPA returns to the login screen and the session is revoked
 


### PR DESCRIPTION
## What / why

Adds validated Plex Web and Plex App handoffs to available title details, including 4K fallback and experimental guidance. Adds optional one-time taste onboarding for users whose cold-start seed produces no signals, reusing existing watchlist signals without blocking browsing. It also improves Plex PIN approval-window cleanup without adding Plex tokens or direct Plex API access.

## Spec

- OpenSpec change: `add-plex-play-and-taste-onboarding`
- [x] Change archived on this branch (if applicable)

## Checklist

- [x] `just check` passes locally
- [x] Title is the Conventional Commit subject for the squash