### PR TITLE
fix: isolate query cache across user sessions

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,11 +1,19 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { afterEach, expect, test, vi } from "vitest";
 import { App } from "./App";
+import { setConfirmedSession } from "./lib/auth";
 
 afterEach(() => {
 	cleanup();
+	vi.restoreAllMocks();
 	vi.unstubAllGlobals();
 });
 
@@ -15,22 +23,54 @@ const USER = {
 	avatar_url: null,
 	is_admin: false,
 };
+const USER_B = {
+	id: 2,
+	display_name: "Viewer B",
+	avatar_url: null,
+	is_admin: false,
+};
 const HOME = {
 	hero: [],
 	rails: [
 		{ id: "trending", title: "Trending Now", kind: "standard", items: [] },
 	],
 };
+const HOME_B = {
+	hero: [],
+	rails: [{ id: "for-b", title: "For Viewer B", kind: "standard", items: [] }],
+};
 const RAILS = { rails: [], next_cursor: null };
+const CONFIG = {
+	seerr_configured: false,
+	plex_login_enabled: true,
+	local_login_enabled: true,
+	appearance: { theme: "dark", accent: "crimson" },
+};
+
+const USER_A_QUERY_DATA = [
+	[["home"], HOME],
+	[["rails"], { pages: [RAILS], pageParams: [0] }],
+	[["title", "movie", 7], { owner: "A", watchlisted: true }],
+	[["search", "private"], { owner: "A" }],
+	[["config"], CONFIG],
+	[["availability", ["movie:7"]], { owner: "A" }],
+	[["explain", "movie", 7], { reasons: ["Viewer A's taste"] }],
+	[["taste-onboarding", USER.id], { state: "done" }],
+	[["admin", "settings"], { owner: "A" }],
+	[["admin", "regions"], { owner: "A" }],
+	[["admin", "services", "US"], { owner: "A" }],
+] as const;
 
 function jsonResponse(body: unknown, status = 200): Response {
 	return { ok: status < 400, status, json: async () => body } as Response;
 }
 
-function renderApp(initialEntry = "/") {
-	const queryClient = new QueryClient({
+function renderApp(
+	initialEntry = "/",
+	queryClient = new QueryClient({
 		defaultOptions: { queries: { retry: false } },
-	});
+	}),
+) {
 	render(
 		<QueryClientProvider client={queryClient}>
 			<MemoryRouter initialEntries={[initialEntry]}>
@@ -38,6 +78,28 @@ function renderApp(initialEntry = "/") {
 			</MemoryRouter>
 		</QueryClientProvider>,
 	);
+	return queryClient;
+}
+
+function primeUserAQueries(queryClient: QueryClient) {
+	queryClient.setQueryData(["auth", "me"], USER);
+	for (const [queryKey, data] of USER_A_QUERY_DATA) {
+		queryClient.setQueryData(queryKey, data);
+	}
+}
+
+function expectUserAQueriesRemoved(queryClient: QueryClient) {
+	for (const [queryKey] of USER_A_QUERY_DATA) {
+		expect(queryClient.getQueryData(queryKey)).toBeUndefined();
+	}
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
 }
 
 test("a non-admin direct settings URL redirects before protected data is fetched", async () => {
@@ -142,4 +204,361 @@ test("logout returns to the login screen", async () => {
 	expect(
 		await screen.findByRole("button", { name: "Sign in with Plex" }),
 	).toBeTruthy();
+});
+
+test("local account switch clears user A data and blocks a late query", async () => {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	primeUserAQueries(queryClient);
+	const lateUserAHome = deferred<typeof HOME>();
+	const lateUserACompleted = deferred<void>();
+	const userBLogin = deferred<Response>();
+	const userBHome = deferred<Response>();
+	const lateRequest = queryClient
+		.fetchQuery({
+			queryKey: ["home"],
+			queryFn: async () => {
+				const home = await lateUserAHome.promise;
+				lateUserACompleted.resolve(undefined);
+				return home;
+			},
+		})
+		.catch(() => undefined);
+	expect(queryClient.getQueryState(["home"])?.fetchStatus).toBe("fetching");
+	const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+		const url = String(input);
+		if (url === "/api/v1/auth/logout") return jsonResponse(null, 204);
+		if (url === "/api/v1/auth/local") return userBLogin.promise;
+		if (url === "/api/v1/home") return userBHome.promise;
+		if (url === "/api/v1/config") return jsonResponse(CONFIG);
+		if (url === "/api/v1/rails?cursor=0") return jsonResponse(RAILS);
+		if (url === "/api/v1/taste-onboarding")
+			return jsonResponse({ state: "done" });
+		throw new Error(`unexpected fetch: ${url}`);
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	renderApp("/", queryClient);
+
+	const signOut = await screen.findByRole("button", { name: "Sign out" });
+	expect(
+		queryClient
+			.getQueryCache()
+			.find({ queryKey: ["home"] })
+			?.getObserversCount(),
+	).toBeGreaterThan(0);
+	expect(queryClient.getQueryState(["home"])?.fetchStatus).toBe("fetching");
+	fireEvent.click(signOut);
+	await screen.findByRole("button", { name: "Sign in with Plex" });
+	expectUserAQueriesRemoved(queryClient);
+	expect(queryClient.getQueryData(["auth", "me"])).toBeNull();
+
+	fireEvent.change(screen.getByLabelText("Email"), {
+		target: { value: "viewer-b@example.test" },
+	});
+	fireEvent.change(screen.getByLabelText("Password"), {
+		target: { value: "password" },
+	});
+	fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+	await waitFor(() =>
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/v1/auth/local",
+			expect.objectContaining({ method: "POST" }),
+		),
+	);
+	expectUserAQueriesRemoved(queryClient);
+	expect(queryClient.getQueryData(["auth", "me"])).toBeNull();
+
+	userBLogin.resolve(jsonResponse(USER_B));
+	expect(await screen.findByText("Viewer B")).toBeTruthy();
+	lateUserAHome.resolve({
+		hero: [],
+		rails: [
+			{
+				id: "private-a",
+				title: "Viewer A Private",
+				kind: "standard",
+				items: [],
+			},
+		],
+	});
+	await lateUserACompleted.promise;
+	await lateRequest;
+	expect(queryClient.getQueryData(["home"])).toBeUndefined();
+	expect(screen.queryByText("Viewer A Private")).toBeNull();
+
+	userBHome.resolve(jsonResponse(HOME_B));
+	expect(await screen.findByText("For Viewer B")).toBeTruthy();
+});
+
+test("Plex account switch clears user A data before user B arrives", async () => {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	primeUserAQueries(queryClient);
+	const plexPoll = deferred<Response>();
+	const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+		const url = String(input);
+		if (url === "/api/v1/auth/logout") return jsonResponse(null, 204);
+		if (url === "/api/v1/auth/plex/pin")
+			return jsonResponse({
+				pin_id: "opaque-handle",
+				auth_url: "https://app.plex.tv/auth#?x",
+			});
+		if (url === "/api/v1/auth/plex/pin/poll") return plexPoll.promise;
+		if (url === "/api/v1/home") return jsonResponse(HOME_B);
+		if (url === "/api/v1/config") return jsonResponse(CONFIG);
+		if (url === "/api/v1/rails?cursor=0") return jsonResponse(RAILS);
+		if (url === "/api/v1/taste-onboarding")
+			return jsonResponse({ state: "done" });
+		throw new Error(`unexpected fetch: ${url}`);
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	vi.stubGlobal(
+		"open",
+		vi.fn(() => null),
+	);
+	vi.spyOn(window, "focus").mockImplementation(() => undefined);
+	renderApp("/", queryClient);
+
+	fireEvent.click(await screen.findByRole("button", { name: "Sign out" }));
+	fireEvent.click(
+		await screen.findByRole("button", { name: "Sign in with Plex" }),
+	);
+	await waitFor(() =>
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/v1/auth/plex/pin/poll",
+			expect.objectContaining({ method: "POST" }),
+		),
+	);
+	expectUserAQueriesRemoved(queryClient);
+	expect(queryClient.getQueryData(["auth", "me"])).toBeNull();
+
+	plexPoll.resolve(jsonResponse({ status: "ok", user: USER_B }));
+	expect(await screen.findByText("Viewer B")).toBeTruthy();
+	expect(queryClient.getQueryData(["auth", "me"])).toEqual(USER_B);
+});
+
+test("initial and same-user auth resolutions preserve existing queries", async () => {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	queryClient.setQueryData(["before-auth"], { keep: true });
+	let meReads = 0;
+	const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+		const url = String(input);
+		if (url === "/api/v1/auth/me") {
+			meReads += 1;
+			return jsonResponse(
+				meReads === 1 ? USER : { ...USER, display_name: "Viewer refreshed" },
+			);
+		}
+		if (url === "/api/v1/home") return jsonResponse(HOME);
+		if (url === "/api/v1/config") return jsonResponse(CONFIG);
+		if (url === "/api/v1/rails?cursor=0") return jsonResponse(RAILS);
+		if (url === "/api/v1/taste-onboarding")
+			return jsonResponse({ state: "done" });
+		throw new Error(`unexpected fetch: ${url}`);
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	renderApp("/", queryClient);
+
+	expect(await screen.findByText("Viewer")).toBeTruthy();
+	expect(queryClient.getQueryData(["before-auth"])).toEqual({ keep: true });
+	queryClient.setQueryData(["same-user"], { keep: true });
+
+	await queryClient.refetchQueries({ queryKey: ["auth", "me"] });
+	expect(await screen.findByText("Viewer refreshed")).toBeTruthy();
+	expect(queryClient.getQueryData(["before-auth"])).toEqual({ keep: true });
+	expect(queryClient.getQueryData(["same-user"])).toEqual({ keep: true });
+});
+
+test("a cancelled auth refresh cannot clear the newer session", async () => {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	const oldMe = deferred<Response>();
+	const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+		const url = String(input);
+		if (url === "/api/v1/auth/me") return oldMe.promise;
+		if (url === "/api/v1/home") return jsonResponse(HOME_B);
+		if (url === "/api/v1/config") return jsonResponse(CONFIG);
+		if (url === "/api/v1/rails?cursor=0") return jsonResponse(RAILS);
+		if (url === "/api/v1/taste-onboarding")
+			return jsonResponse({ state: "done" });
+		throw new Error(`unexpected fetch: ${url}`);
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	renderApp("/", queryClient);
+
+	expect(await screen.findByText("Loading…")).toBeTruthy();
+	await waitFor(() =>
+		expect(fetchMock).toHaveBeenCalledWith("/api/v1/auth/me", undefined),
+	);
+	await setConfirmedSession(queryClient, USER_B);
+	expect(await screen.findByText("Viewer B")).toBeTruthy();
+	queryClient.setQueryData(["session-b"], { owner: "B" });
+
+	oldMe.resolve(jsonResponse(USER));
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	expect(queryClient.getQueryData(["auth", "me"])).toEqual(USER_B);
+	expect(queryClient.getQueryData(["session-b"])).toEqual({ owner: "B" });
+	expect(screen.getByText("Viewer B")).toBeTruthy();
+});
+
+test("auth refresh clears user A data before publishing user B", async () => {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	primeUserAQueries(queryClient);
+	const userBMe = deferred<Response>();
+	const userBHome = deferred<Response>();
+	const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+		const url = String(input);
+		if (url === "/api/v1/auth/me") return userBMe.promise;
+		if (url === "/api/v1/home") return userBHome.promise;
+		if (url === "/api/v1/config") return jsonResponse(CONFIG);
+		if (url === "/api/v1/rails?cursor=0") return jsonResponse(RAILS);
+		if (url === "/api/v1/taste-onboarding")
+			return jsonResponse({ state: "done" });
+		throw new Error(`unexpected fetch: ${url}`);
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	renderApp("/", queryClient);
+	expect(await screen.findByText("Viewer")).toBeTruthy();
+	expect(screen.getByText("Trending Now")).toBeTruthy();
+
+	const refresh = queryClient.refetchQueries({ queryKey: ["auth", "me"] });
+	await waitFor(() =>
+		expect(fetchMock).toHaveBeenCalledWith("/api/v1/auth/me", undefined),
+	);
+	userBMe.resolve(jsonResponse(USER_B));
+	await refresh;
+	expect(await screen.findByText("Viewer B")).toBeTruthy();
+	expect(queryClient.getQueryData(["home"])).toBeUndefined();
+	expect(queryClient.getQueryData(["title", "movie", 7])).toBeUndefined();
+	expect(queryClient.getQueryData(["explain", "movie", 7])).toBeUndefined();
+	expect(
+		queryClient.getQueryData(["taste-onboarding", USER.id]),
+	).toBeUndefined();
+	expect(queryClient.getQueryData(["admin", "settings"])).toBeUndefined();
+	expect(screen.queryByText("Trending Now")).toBeNull();
+
+	userBHome.resolve(jsonResponse(HOME_B));
+	expect(await screen.findByText("For Viewer B")).toBeTruthy();
+});
+
+test("a late logout response cannot replace a newer confirmed user", async () => {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	primeUserAQueries(queryClient);
+	const lateLogout = deferred<Response>();
+	const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+		const url = String(input);
+		if (url === "/api/v1/auth/logout") return lateLogout.promise;
+		if (url === "/api/v1/auth/me")
+			return jsonResponse({ detail: "Not authenticated" }, 401);
+		if (url === "/api/v1/auth/local") return jsonResponse(USER_B);
+		if (url === "/api/v1/home") return jsonResponse(HOME_B);
+		if (url === "/api/v1/config") return jsonResponse(CONFIG);
+		if (url === "/api/v1/rails?cursor=0") return jsonResponse(RAILS);
+		if (url === "/api/v1/taste-onboarding")
+			return jsonResponse({ state: "done" });
+		throw new Error(`unexpected fetch: ${url}`);
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	renderApp("/", queryClient);
+
+	fireEvent.click(await screen.findByRole("button", { name: "Sign out" }));
+	await waitFor(() =>
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/v1/auth/logout",
+			expect.objectContaining({ method: "POST" }),
+		),
+	);
+	await queryClient.refetchQueries({ queryKey: ["auth", "me"] });
+	await screen.findByRole("button", { name: "Sign in with Plex" });
+
+	fireEvent.change(screen.getByLabelText("Email"), {
+		target: { value: "viewer-b@example.test" },
+	});
+	fireEvent.change(screen.getByLabelText("Password"), {
+		target: { value: "password" },
+	});
+	fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+	expect(await screen.findByText("Viewer B")).toBeTruthy();
+
+	lateLogout.resolve(jsonResponse(null, 204));
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	expect(queryClient.getQueryData(["auth", "me"])).toEqual(USER_B);
+	expect(screen.getByText("Viewer B")).toBeTruthy();
+	expect(
+		screen.queryByRole("button", { name: "Sign in with Plex" }),
+	).toBeNull();
+});
+
+test("failed logout preserves the confirmed session and its cache", async () => {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	primeUserAQueries(queryClient);
+	const logoutFailure = deferred<Response>();
+	const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+		const url = String(input);
+		if (url === "/api/v1/auth/logout") return logoutFailure.promise;
+		if (url === "/api/v1/taste-onboarding")
+			return jsonResponse({ state: "done" });
+		throw new Error(`unexpected fetch: ${url}`);
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	renderApp("/", queryClient);
+
+	fireEvent.click(await screen.findByRole("button", { name: "Sign out" }));
+	await waitFor(() =>
+		expect(
+			(screen.getByRole("button", { name: "Sign out" }) as HTMLButtonElement)
+				.disabled,
+		).toBe(true),
+	);
+	logoutFailure.resolve(jsonResponse({ detail: "Logout failed" }, 503));
+	await waitFor(() =>
+		expect(
+			(screen.getByRole("button", { name: "Sign out" }) as HTMLButtonElement)
+				.disabled,
+		).toBe(false),
+	);
+	expect(queryClient.getQueryData(["auth", "me"])).toEqual(USER);
+	expect(queryClient.getQueryData(["title", "movie", 7])).toEqual({
+		owner: "A",
+		watchlisted: true,
+	});
+	expect(screen.getByText("Viewer")).toBeTruthy();
+});
+
+test("failed local login preserves the confirmed signed-out state and cache", async () => {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	queryClient.setQueryData(["auth", "me"], null);
+	queryClient.setQueryData(["pre-login"], "keep");
+	vi.stubGlobal(
+		"fetch",
+		vi.fn(async () =>
+			jsonResponse({ detail: "Invalid email or password" }, 401),
+		),
+	);
+	renderApp("/", queryClient);
+
+	fireEvent.change(screen.getByLabelText("Email"), {
+		target: { value: "viewer-b@example.test" },
+	});
+	fireEvent.change(screen.getByLabelText("Password"), {
+		target: { value: "wrong" },
+	});
+	fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+	expect(await screen.findByText("Invalid email or password")).toBeTruthy();
+	expect(queryClient.getQueryData(["auth", "me"])).toBeNull();
+	expect(queryClient.getQueryData(["pre-login"])).toBe("keep");
 });

--- a/frontend/src/lib/admin.ts
+++ b/frontend/src/lib/admin.ts
@@ -7,6 +7,7 @@ import {
 	saveSettings,
 	testConnection,
 } from "./api";
+import { captureSession, isSessionCurrent } from "./auth";
 
 export const SETTINGS_QUERY_KEY = ["admin", "settings"] as const;
 
@@ -40,7 +41,9 @@ export function useSaveSettings() {
 	const queryClient = useQueryClient();
 	return useMutation({
 		mutationFn: (settings: RuntimeSettings) => saveSettings(settings),
-		onSuccess: (response) => {
+		onMutate: () => captureSession(queryClient),
+		onSuccess: (response, _settings, sessionEpoch) => {
+			if (!isSessionCurrent(queryClient, sessionEpoch)) return;
 			queryClient.setQueryData(SETTINGS_QUERY_KEY, response);
 			queryClient.setQueryData(["config"], (current: object | undefined) =>
 				current

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,12 +1,74 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { getMe, logout } from "./api";
+import {
+	type QueryClient,
+	useMutation,
+	useQuery,
+	useQueryClient,
+} from "@tanstack/react-query";
+import { getMe, logout, type User } from "./api";
 
 export const ME_QUERY_KEY = ["auth", "me"] as const;
+const sessionEpochs = new WeakMap<QueryClient, number>();
+
+function isMeQuery(queryKey: readonly unknown[]): boolean {
+	return (
+		queryKey.length === ME_QUERY_KEY.length &&
+		queryKey.every((part, index) => part === ME_QUERY_KEY[index])
+	);
+}
+
+function getSessionEpoch(queryClient: QueryClient): number {
+	return sessionEpochs.get(queryClient) ?? 0;
+}
+
+export function isSessionCurrent(
+	queryClient: QueryClient,
+	epoch: number,
+): boolean {
+	return getSessionEpoch(queryClient) === epoch;
+}
+
+export function captureSession(queryClient: QueryClient): number {
+	return getSessionEpoch(queryClient);
+}
+
+async function clearSessionState(
+	queryClient: QueryClient,
+	cancelMe: boolean,
+): Promise<void> {
+	sessionEpochs.set(queryClient, getSessionEpoch(queryClient) + 1);
+	queryClient.getMutationCache().clear();
+	await queryClient.cancelQueries({
+		predicate: ({ queryKey }) => cancelMe || !isMeQuery(queryKey),
+	});
+	queryClient.removeQueries({
+		predicate: ({ queryKey }) => !isMeQuery(queryKey),
+	});
+}
+
+export async function setConfirmedSession(
+	queryClient: QueryClient,
+	user: User | null,
+): Promise<void> {
+	await clearSessionState(queryClient, true);
+	queryClient.setQueryData(ME_QUERY_KEY, user);
+}
 
 export function useMe() {
+	const queryClient = useQueryClient();
 	return useQuery({
 		queryKey: ME_QUERY_KEY,
-		queryFn: getMe,
+		queryFn: async ({ signal }) => {
+			const user = await getMe();
+			const currentUser = queryClient.getQueryData<User | null>(ME_QUERY_KEY);
+			if (
+				!signal.aborted &&
+				currentUser !== undefined &&
+				currentUser?.id !== user?.id
+			) {
+				await clearSessionState(queryClient, false);
+			}
+			return user;
+		},
 		staleTime: 60_000,
 		retry: false,
 	});
@@ -16,6 +78,11 @@ export function useLogout() {
 	const queryClient = useQueryClient();
 	return useMutation({
 		mutationFn: logout,
-		onSettled: () => queryClient.invalidateQueries({ queryKey: ME_QUERY_KEY }),
+		onMutate: () => captureSession(queryClient),
+		onSuccess: (_data, _variables, sessionEpoch) => {
+			if (isSessionCurrent(queryClient, sessionEpoch)) {
+				return setConfirmedSession(queryClient, null);
+			}
+		},
 	});
 }

--- a/frontend/src/lib/availability.ts
+++ b/frontend/src/lib/availability.ts
@@ -15,6 +15,7 @@ import {
 	type MediaType,
 	postAvailability,
 } from "./api";
+import { captureSession, isSessionCurrent } from "./auth";
 
 export function availabilityKey(mediaType: MediaType, id: number): string {
 	return `${mediaType}:${id}`;
@@ -81,7 +82,9 @@ export function useRequest(type: MediaType, id: number) {
 	const queryClient = useQueryClient();
 	return useMutation({
 		mutationFn: () => createRequest(type, id),
-		onSuccess: (response) => {
+		onMutate: () => captureSession(queryClient),
+		onSuccess: (response, _variables, sessionEpoch) => {
+			if (!isSessionCurrent(queryClient, sessionEpoch)) return;
 			if (response.status === "ok" && response.availability) {
 				const next = response.availability;
 				// Flip this title's detail badge immediately, and let card badges

--- a/frontend/src/lib/taste.test.tsx
+++ b/frontend/src/lib/taste.test.tsx
@@ -1,0 +1,75 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+import { setConfirmedSession } from "./auth";
+import { useTasteToggle } from "./taste";
+
+afterEach(() => {
+	cleanup();
+	vi.unstubAllGlobals();
+});
+
+const USER_B = {
+	id: 2,
+	display_name: "Viewer B",
+	avatar_url: null,
+	is_admin: false,
+};
+
+function Toggle({ initial }: { initial: boolean }) {
+	const toggle = useTasteToggle("movie", 7, "not_interested", initial);
+	return (
+		<button type="button" onClick={toggle.toggle} disabled={toggle.pending}>
+			{toggle.active ? "Hidden" : "Visible"}
+		</button>
+	);
+}
+
+test("a failed prior-session toggle cannot restore its user's state", async () => {
+	let rejectSignal!: (reason: Error) => void;
+	const signal = new Promise<Response>((_resolve, reject) => {
+		rejectSignal = reject;
+	});
+	const fetchMock = vi.fn(() => signal);
+	vi.stubGlobal("fetch", fetchMock);
+	const queryClient = new QueryClient({
+		defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+	});
+	const view = render(
+		<QueryClientProvider client={queryClient}>
+			<Toggle initial={true} />
+		</QueryClientProvider>,
+	);
+
+	fireEvent.click(screen.getByRole("button", { name: "Hidden" }));
+	await waitFor(() =>
+		expect(
+			(screen.getByRole("button", { name: "Visible" }) as HTMLButtonElement)
+				.disabled,
+		).toBe(true),
+	);
+	await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+
+	await setConfirmedSession(queryClient, USER_B);
+	view.rerender(
+		<QueryClientProvider client={queryClient}>
+			<Toggle initial={false} />
+		</QueryClientProvider>,
+	);
+	rejectSignal(new Error("late user-A failure"));
+	await new Promise((resolve) => setTimeout(resolve, 0));
+
+	await waitFor(() =>
+		expect(
+			(screen.getByRole("button", { name: "Visible" }) as HTMLButtonElement)
+				.disabled,
+		).toBe(false),
+	);
+	expect(screen.getByRole("button", { name: "Visible" })).toBeTruthy();
+});

--- a/frontend/src/lib/taste.ts
+++ b/frontend/src/lib/taste.ts
@@ -13,6 +13,7 @@ import {
 	type TasteOnboardingSelection,
 	type TasteOnboardingStateResponse,
 } from "./api";
+import { captureSession, isSessionCurrent } from "./auth";
 
 /** Fire-and-forget detail-open signal: errors are deliberately swallowed. */
 export function recordDetailOpen(type: MediaType, id: number): void {
@@ -35,8 +36,20 @@ export function useTasteToggle(
 	useEffect(() => setActive(initial), [initial]);
 	const mutation = useMutation({
 		mutationFn: (wasActive: boolean) => postSignal(type, id, kind, wasActive),
-		onError: (_error, wasActive) => setActive(wasActive), // revert the flip
-		onSuccess: () => queryClient.invalidateQueries({ queryKey: ["home"] }),
+		onMutate: () => captureSession(queryClient),
+		onError: (_error, wasActive, sessionEpoch) => {
+			if (
+				sessionEpoch !== undefined &&
+				isSessionCurrent(queryClient, sessionEpoch)
+			) {
+				setActive(wasActive);
+			}
+		},
+		onSuccess: (_data, _wasActive, sessionEpoch) => {
+			if (isSessionCurrent(queryClient, sessionEpoch)) {
+				return queryClient.invalidateQueries({ queryKey: ["home"] });
+			}
+		},
 	});
 	const toggle = () => {
 		const wasActive = active;
@@ -60,7 +73,12 @@ export function useResetRecommendations() {
 	const queryClient = useQueryClient();
 	return useMutation({
 		mutationFn: resetRecommendations,
-		onSuccess: () => queryClient.invalidateQueries({ queryKey: ["home"] }),
+		onMutate: () => captureSession(queryClient),
+		onSuccess: (_data, _variables, sessionEpoch) => {
+			if (isSessionCurrent(queryClient, sessionEpoch)) {
+				return queryClient.invalidateQueries({ queryKey: ["home"] });
+			}
+		},
 	});
 }
 
@@ -85,7 +103,9 @@ export function useCompleteTasteOnboarding(userId: number | undefined) {
 	return useMutation({
 		mutationFn: (selections: TasteOnboardingSelection[]) =>
 			completeTasteOnboarding(selections),
-		onSuccess: () => {
+		onMutate: () => captureSession(queryClient),
+		onSuccess: (_data, _selections, sessionEpoch) => {
+			if (!isSessionCurrent(queryClient, sessionEpoch)) return;
 			queryClient.setQueryData<TasteOnboardingStateResponse>(
 				tasteOnboardingKey(userId),
 				{ state: "done" },

--- a/frontend/src/routes/Login.test.tsx
+++ b/frontend/src/routes/Login.test.tsx
@@ -37,17 +37,17 @@ function stubFetch(routes: Record<string, Route>) {
 	return mock;
 }
 
-function renderLogin() {
-	const queryClient = new QueryClient({
+function renderLogin(
+	queryClient = new QueryClient({
 		defaultOptions: { queries: { retry: false } },
-	});
-	const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+	}),
+) {
 	render(
 		<QueryClientProvider client={queryClient}>
 			<Login />
 		</QueryClientProvider>,
 	);
-	return invalidate;
+	return queryClient;
 }
 
 const USER = {
@@ -92,7 +92,11 @@ test("plex flow protects and closes its approval window after polling succeeds",
 	const open = vi.fn(() => approval);
 	vi.stubGlobal("open", open);
 	const parentFocus = vi.mocked(window.focus);
-	const invalidate = renderLogin();
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	queryClient.setQueryData(["title", "movie", 7], { owner: "A" });
+	renderLogin(queryClient);
 
 	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
 
@@ -111,12 +115,59 @@ test("plex flow protects and closes its approval window after polling succeeds",
 		interval: 100,
 	});
 	await vi.waitFor(
-		() => expect(invalidate).toHaveBeenCalledWith({ queryKey: ME_QUERY_KEY }),
+		() => expect(queryClient.getQueryData(ME_QUERY_KEY)).toEqual(USER),
 		{ timeout: 5000 },
 	);
 	expect(close).toHaveBeenCalledOnce();
 	expect(parentFocus).toHaveBeenCalledOnce();
+	expect(queryClient.getQueryData(["title", "movie", 7])).toBeUndefined();
+	expect(
+		queryClient.getQueriesData({ queryKey: ["auth", "plex-pin"] }),
+	).toEqual([]);
+	expect(queryClient.getMutationCache().getAll()).toEqual([]);
 }, 15000);
+
+test("plex flow rejects a completed poll without a user", async () => {
+	stubFetch({
+		"POST /api/v1/auth/plex/pin": () => ({
+			status: 200,
+			body: {
+				pin_id: "opaque-handle",
+				auth_url: "https://app.plex.tv/auth#?x",
+			},
+		}),
+		"POST /api/v1/auth/plex/pin/poll": () => ({
+			status: 200,
+			body: { status: "ok", user: null },
+		}),
+	});
+	const { approval, close } = fakeApprovalWindow();
+	vi.stubGlobal(
+		"open",
+		vi.fn(() => approval),
+	);
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	queryClient.setQueryData(["pre-login"], "keep");
+	renderLogin(queryClient);
+
+	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
+
+	expect(
+		await screen.findByText("Plex sign-in failed — try again."),
+	).toBeTruthy();
+	expect(close).toHaveBeenCalledOnce();
+	expect(queryClient.getQueryData(["pre-login"])).toBe("keep");
+	expect(queryClient.getQueryData(ME_QUERY_KEY)).toBeUndefined();
+	expect(
+		(
+			screen.getByRole("button", {
+				name: "Sign in with Plex",
+			}) as HTMLButtonElement
+		).disabled,
+	).toBe(false);
+});
 
 test("plex flow: expired handle surfaces a retry message", async () => {
 	stubFetch({
@@ -188,12 +239,12 @@ test("plex flow can complete when the approval window is blocked", async () => {
 		"open",
 		vi.fn(() => null),
 	);
-	const invalidate = renderLogin();
+	const queryClient = renderLogin();
 
 	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
 
 	await vi.waitFor(() =>
-		expect(invalidate).toHaveBeenCalledWith({ queryKey: ME_QUERY_KEY }),
+		expect(queryClient.getQueryData(ME_QUERY_KEY)).toEqual(USER),
 	);
 });
 
@@ -255,12 +306,12 @@ test("plex flow can complete after the user closes the approval window", async (
 		"open",
 		vi.fn(() => approval),
 	);
-	const invalidate = renderLogin();
+	const queryClient = renderLogin();
 
 	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
 
 	await vi.waitFor(() =>
-		expect(invalidate).toHaveBeenCalledWith({ queryKey: ME_QUERY_KEY }),
+		expect(queryClient.getQueryData(ME_QUERY_KEY)).toEqual(USER),
 	);
 	expect(replace).not.toHaveBeenCalled();
 	expect(close).not.toHaveBeenCalled();
@@ -295,12 +346,12 @@ test("plex flow can complete when the browser severs the approval proxy", async 
 		"open",
 		vi.fn(() => approval),
 	);
-	const invalidate = renderLogin();
+	const queryClient = renderLogin();
 
 	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
 
 	await vi.waitFor(() =>
-		expect(invalidate).toHaveBeenCalledWith({ queryKey: ME_QUERY_KEY }),
+		expect(queryClient.getQueryData(ME_QUERY_KEY)).toEqual(USER),
 	);
 	expect(approval.location.replace).not.toHaveBeenCalled();
 });
@@ -309,7 +360,11 @@ test("local login posts credentials and refreshes auth state", async () => {
 	const mock = stubFetch({
 		"/api/v1/auth/local": () => ({ status: 200, body: USER }),
 	});
-	const invalidate = renderLogin();
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	queryClient.setQueryData(["home"], { owner: "A" });
+	renderLogin(queryClient);
 
 	fireEvent.change(screen.getByLabelText("Email"), {
 		target: { value: "a@b.c" },
@@ -320,8 +375,10 @@ test("local login posts credentials and refreshes auth state", async () => {
 	fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
 
 	await vi.waitFor(() => {
-		expect(invalidate).toHaveBeenCalledWith({ queryKey: ME_QUERY_KEY });
+		expect(queryClient.getQueryData(ME_QUERY_KEY)).toEqual(USER);
 	});
+	expect(queryClient.getQueryData(["home"])).toBeUndefined();
+	expect(queryClient.getMutationCache().getAll()).toEqual([]);
 	expect(mock).toHaveBeenCalledWith(
 		"/api/v1/auth/local",
 		expect.objectContaining({

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -7,7 +7,7 @@ import {
 	useState,
 } from "react";
 import { ApiError, createPlexPin, loginLocal, pollPlexPin } from "../lib/api";
-import { ME_QUERY_KEY } from "../lib/auth";
+import { setConfirmedSession } from "../lib/auth";
 
 interface PendingPin {
 	pinId: string;
@@ -91,13 +91,19 @@ export function Login() {
 
 	useEffect(() => {
 		if (pollData?.status === "ok") {
+			if (pollData.user == null) {
+				closeApprovalWindow();
+				setPlexError("Plex sign-in failed — try again.");
+				setPin(null);
+				return;
+			}
 			closeApprovalWindow();
 			try {
 				window.focus();
 			} catch {
 				// Browsers may reject programmatic focus after cross-origin navigation.
 			}
-			void queryClient.invalidateQueries({ queryKey: ME_QUERY_KEY });
+			void setConfirmedSession(queryClient, pollData.user);
 		}
 	}, [pollData, queryClient, closeApprovalWindow]);
 
@@ -118,8 +124,7 @@ export function Login() {
 	const localLogin = useMutation({
 		mutationFn: (credentials: { email: string; password: string }) =>
 			loginLocal(credentials.email, credentials.password),
-		onSuccess: () =>
-			void queryClient.invalidateQueries({ queryKey: ME_QUERY_KEY }),
+		onSuccess: (user) => setConfirmedSession(queryClient, user),
 	});
 
 	function submitLocal(event: FormEvent<HTMLFormElement>) {

--- a/frontend/src/routes/Settings.test.tsx
+++ b/frontend/src/routes/Settings.test.tsx
@@ -8,6 +8,7 @@ import {
 } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { afterEach, expect, test, vi } from "vitest";
+import { setConfirmedSession } from "../lib/auth";
 import { Settings } from "./Settings";
 
 afterEach(() => {
@@ -50,11 +51,13 @@ function response(body: unknown, status = 200): Response {
 	return { ok: status < 400, status, json: async () => body } as Response;
 }
 
-function renderSettings(fetchMock: ReturnType<typeof vi.fn>) {
-	vi.stubGlobal("fetch", fetchMock);
-	const queryClient = new QueryClient({
+function renderSettings(
+	fetchMock: ReturnType<typeof vi.fn>,
+	queryClient = new QueryClient({
 		defaultOptions: { queries: { retry: false } },
-	});
+	}),
+) {
+	vi.stubGlobal("fetch", fetchMock);
 	render(
 		<QueryClientProvider client={queryClient}>
 			<MemoryRouter>
@@ -63,6 +66,14 @@ function renderSettings(fetchMock: ReturnType<typeof vi.fn>) {
 		</QueryClientProvider>,
 	);
 	return queryClient;
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
 }
 
 function routeAdminFetch() {
@@ -145,4 +156,58 @@ test("connection results are announced without exposing configuration", async ()
 	expect(result.tagName).toBe("OUTPUT");
 	const post = fetchMock.mock.calls.find(([, init]) => init?.method === "POST");
 	expect(JSON.parse(String(post?.[1]?.body))).toEqual({ target: "tmdb" });
+});
+
+test("a late save cannot repopulate cache after the session changes", async () => {
+	const lateSave = deferred<Response>();
+	const baseFetch = routeAdminFetch();
+	const fetchMock = vi.fn(
+		async (input: RequestInfo | URL, init?: RequestInit) => {
+			if (String(input) === "/api/v1/settings" && init?.method === "PUT") {
+				return lateSave.promise;
+			}
+			return baseFetch(input, init);
+		},
+	);
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	queryClient.setQueryData(["auth", "me"], {
+		id: 1,
+		display_name: "Viewer A",
+		avatar_url: null,
+		is_admin: true,
+	});
+	renderSettings(fetchMock, queryClient);
+	await screen.findByLabelText("Netflix");
+
+	fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+	await waitFor(() =>
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/v1/settings",
+			expect.objectContaining({ method: "PUT" }),
+		),
+	);
+	expect(queryClient.getMutationCache().getAll()).toHaveLength(1);
+	await setConfirmedSession(queryClient, {
+		id: 2,
+		display_name: "Viewer B",
+		avatar_url: null,
+		is_admin: true,
+	});
+	expect(queryClient.getMutationCache().getAll()).toEqual([]);
+
+	lateSave.resolve(response({ ...SETTINGS, owner: "A-late" }));
+	await waitFor(() =>
+		expect(
+			(
+				screen.getByRole("button", {
+					name: "Save settings",
+				}) as HTMLButtonElement
+			).disabled,
+		).toBe(false),
+	);
+	expect(
+		queryClient.getQueryData<{ owner?: string }>(["admin", "settings"])?.owner,
+	).toBeUndefined();
 });

--- a/openspec/specs/user-auth/spec.md
+++ b/openspec/specs/user-auth/spec.md
@@ -203,7 +203,13 @@ A blocked, manually closed, or browser-severed context SHALL NOT block polling o
 successful login, and the user SHALL be able to reopen a new protected approval
 context. On success the SPA SHALL switch to the authenticated state without a full
 reload; a logout control SHALL end the session and return to the login screen.
-Failures SHALL surface as generic, human-readable messages.
+Failures SHALL surface as generic, human-readable messages. On each confirmed
+session transition — successful local login, successful Plex PIN completion,
+successful logout, or `auth/me` resolving to a different user — the SPA SHALL
+invalidate prior-session mutation callbacks, cancel in-flight TanStack Query
+requests before removing cached query data, and publish the confirmed user or
+signed-out state only after that boundary completes. Failed login or logout
+attempts SHALL preserve the current confirmed auth state and query cache.
 
 #### Scenario: Plex login from the SPA
 
@@ -233,6 +239,35 @@ Failures SHALL surface as generic, human-readable messages.
 
 - **WHEN** the user activates logout
 - **THEN** the SPA returns to the login screen and the session is revoked
+
+#### Scenario: Shared browser changes household user
+
+- **WHEN** one household user logs out and another completes local or Plex login
+- **THEN** no cached response from the prior user renders while the new user's
+  responses are loading
+
+#### Scenario: Prior-session query completes late
+
+- **WHEN** an in-flight query from the prior session completes after a confirmed
+  session transition
+- **THEN** its response does not repopulate the active query cache
+
+#### Scenario: Current-user refresh detects a different identity
+
+- **WHEN** `auth/me` refetches after the browser session cookie changes from one
+  household user to another
+- **THEN** the prior user's query data is removed before the new identity renders
+
+#### Scenario: Prior-session mutation completes late
+
+- **WHEN** a mutation from the prior session completes after a confirmed session
+  transition
+- **THEN** its callback does not alter the active session's UI or cached queries
+
+#### Scenario: Auth transition fails
+
+- **WHEN** login or logout fails before a new session state is confirmed
+- **THEN** the SPA preserves the current confirmed auth state and cached data
 
 ### Requirement: Live Seerr contract tests
 A pytest-marked live suite (excluded from `just check` and CI) SHALL validate the
@@ -265,4 +300,3 @@ or influence cookie security.
 #### Scenario: Untrusted forwarding headers are ignored
 - **WHEN** a non-allowlisted peer supplies forwarded client IP or scheme headers
 - **THEN** auth uses the socket peer and direct request scheme instead
-


### PR DESCRIPTION
## What / why

Tasterr previously refreshed `["auth", "me"]` on confirmed login/logout while leaving other TanStack Query data and late callbacks alive, which could briefly expose a prior household user's cached data on a shared browser. This centralizes confirmed session boundaries so previous-session mutations are invalidated, in-flight queries are cancelled before cache removal, and the confirmed auth state is published only afterward. Regression coverage exercises local and Plex login, logout, passive identity changes, late query/mutation completion, and failed auth transitions with shared `QueryClient` instances.

## Spec

- OpenSpec change: `n/a: security bug fix restoring session isolation`
- [x] Change archived on this branch (not applicable: no active change artifact)

## Checklist

- [x] `just check` passes locally
- [x] Title is the Conventional Commit subject for the squash
