### PR TITLE
chore: prepare v1.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ values listed above. Pin the desired version from the
 ```yaml
 services:
   tasterr:
-    image: ghcr.io/zacharyarthur/tasterr:1.0.2
+    image: ghcr.io/zacharyarthur/tasterr:1.1.0
     restart: unless-stopped
     ports:
       - "127.0.0.1:8000:8000"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tasterr"
-version = "1.0.2"
+version = "1.1.0"
 description = "Self-hosted, Netflix-style discovery front-end for a household media stack"
 license = "AGPL-3.0-only"
 requires-python = ">=3.13"

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -56,7 +56,7 @@ def test_readme_links_every_living_operator_document() -> None:
     assert "A shared Docker network is not required" in readme
     assert "TASTERR_HTTP_PORT=8000" in readme
     assert "github.com/ZacharyArthur/tasterr/actions/workflows/gate.yml/badge.svg" in readme
-    assert "image: ghcr.io/zacharyarthur/tasterr:1.0.2" in readme
+    assert "image: ghcr.io/zacharyarthur/tasterr:1.1.0" in readme
     assert '- "127.0.0.1:8000:8000"' in readme
     assert "tasterr-data:/data" in readme
     assert "does not require a\n`.env` file" in readme
@@ -81,12 +81,12 @@ def test_readme_links_every_living_operator_document() -> None:
     assert "This is a Compose concern, not an application requirement" in configuration
 
     releasing = _read(DOCS / "RELEASING.md")
-    evidence = _read(DOCS / "releases" / "v1.0.2.md")
+    evidence = _read(DOCS / "releases" / "v1.1.0.md")
     assert "OWNER/REPOSITORY" not in readme + releasing + evidence
     assert "empty **public** `ZacharyArthur/tasterr` repository" in releasing
     assert "`check`, `e2e`, `container-smoke`, and `CodeQL`" in releasing
     assert "leave the existing `sha-<full-commit>` candidate unchanged" in releasing
-    assert "pin the `1.0.2` digest" in releasing
+    assert "pin the `1.1.0` digest" in releasing
     assert "GitHub Release is the authoritative post-tag record" in releasing
     assert "do not create a post-release evidence commit" in releasing
     assert "do not move, delete, or reuse the published tag" in releasing
@@ -139,7 +139,7 @@ def test_release_check_is_deterministic_and_keeps_external_checks_explicit() -> 
     assert "just release-check" in releasing
     assert "just audit" in releasing
     assert "just test-live" in releasing
-    assert "v1.0.2" in releasing
+    assert "v1.1.0" in releasing
     assert "archive <change-id>" in releasing
 
 

--- a/backend/tests/test_release_version.py
+++ b/backend/tests/test_release_version.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from pydantic import BaseModel
 
 ROOT = Path(__file__).resolve().parents[2]
-VERSION = "1.0.2"
+VERSION = "1.1.0"
 
 
 class PackageManifest(BaseModel):
@@ -41,7 +41,7 @@ def test_image_workflow_maps_v1_tag_to_release_aliases() -> None:
 
 def test_release_documents_name_the_current_stable_tag() -> None:
     releasing = (ROOT / "docs" / "RELEASING.md").read_text(encoding="utf-8")
-    evidence = (ROOT / "docs" / "releases" / "v1.0.2.md").read_text(encoding="utf-8")
+    evidence = (ROOT / "docs" / "releases" / "v1.1.0.md").read_text(encoding="utf-8")
 
     assert f"package version is\n`{VERSION}`" in releasing
     assert f"Git tag is `v{VERSION}`" in releasing

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -695,11 +695,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "tasterr"
-version = "1.0.2"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,7 +1,7 @@
 # Releasing
 
 This procedure is for stable v1 releases. The current package version is
-`1.0.2`, its Git tag is `v1.0.2`, and its image is published by the `image` workflow
+`1.1.0`, its Git tag is `v1.1.0`, and its image is published by the `image` workflow
 only after all release changes are squash-merged to protected `main`. The published
 `v1.0.0` tag is retained for provenance, but no GitHub Release was announced for it;
 `v1.0.1` is the immutable-tag fix-forward and first announced release.
@@ -46,7 +46,7 @@ native image/Compose smoke sequentially. Any failure blocks the release.
 npx @devcontainers/cli exec --workspace-folder . just release-check
 ```
 
-Record the date and result in `docs/releases/v1.0.2.md`. This command intentionally
+Record the date and result in `docs/releases/v1.1.0.md`. This command intentionally
 does not imply that audits, security review, or live contracts passed.
 
 For subsequent releases, the committed evidence file is the pre-tag record. Write
@@ -195,16 +195,16 @@ pushes.
 After every pre-tag release-record field is final, create and push the annotated tag:
 
 ```console
-npx @devcontainers/cli exec --workspace-folder . git tag -a v1.0.2 -m "v1.0.2"
-npx @devcontainers/cli exec --workspace-folder . git push origin v1.0.2
+npx @devcontainers/cli exec --workspace-folder . git tag -a v1.1.0 -m "v1.1.0"
+npx @devcontainers/cli exec --workspace-folder . git push origin v1.1.0
 ```
 
-Wait for the image workflow. It must publish `1.0.2`, `1.0`, `1`, and `latest`, and
+Wait for the image workflow. It must publish `1.1.0`, `1.1`, `1`, and `latest`, and
 leave the existing `sha-<full-commit>` candidate unchanged. Inspect the stable
 manifest and confirm both platforms:
 
 ```console
-npx @devcontainers/cli exec --workspace-folder . docker buildx imagetools inspect ghcr.io/zacharyarthur/tasterr:1.0.2
+npx @devcontainers/cli exec --workspace-folder . docker buildx imagetools inspect ghcr.io/zacharyarthur/tasterr:1.1.0
 ```
 
 The historical v1.0.1 image has no attestation. For subsequent releases, substitute
@@ -216,15 +216,15 @@ gh attestation verify oci://ghcr.io/zacharyarthur/tasterr:<version> -R ZacharyAr
 
 Perform a fresh install in an empty directory with a new external network, disposable
 `.env`, and new Compose project. Set
-`TASTERR_IMAGE=ghcr.io/zacharyarthur/tasterr:1.0.2`, run `docker compose pull` and
+`TASTERR_IMAGE=ghcr.io/zacharyarthur/tasterr:1.1.0`, run `docker compose pull` and
 `docker compose up -d --no-build`, then verify health, SPA serving, non-root uid, and
 named-volume persistence. Delete every disposable resource after verification.
 
 Publish release notes only after the applicable manifest, attestation, and fresh
 install checks pass. Summarize user-visible changes, upgrade steps, and known
-limitations; then pin the `1.0.2` digest as the released artifact without reproducing
-private evidence. The historical v1.0.1 GitHub Release is mutable. Publish v1.0.2
-with repository immutability enabled only after `1.0.2`, `1.0`, `1`, and `latest`
+limitations; then pin the `1.1.0` digest as the released artifact without reproducing
+private evidence. The historical v1.0.1 GitHub Release is mutable. Publish v1.1.0
+with repository immutability enabled only after `1.1.0`, `1.1`, `1`, and `latest`
 resolve to the expected release commit, the `sha-<full-commit>` candidate retains its
 recorded pre-tag digest, and the tagged clean-install smoke passes.
 

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -1,0 +1,99 @@
+# Tasterr v1.1.0 release evidence
+
+- Release date: 2026-08-22
+- Git tag: `v1.1.0`
+- Evidence status: approved for release after the automated pre-tag controls and
+  documented live-contract exception. The GitHub Release will be the authoritative
+  record for the final manifest digest, publication time, alias verification, and
+  tagged-image smoke result.
+
+## Scope
+
+- Home uses honest `Recent Releases` labels, selected-service release rails cover
+  the preceding 365 days, and every curated movie genre not selected for Home stays
+  reachable through additional rail pages.
+- Available title details expose validated, token-free Plex Web and Plex App
+  handoffs with regular-to-4K fallback and explicit experimental guidance. Plex PIN
+  login also cleans up its protected approval window best-effort without making
+  popup behavior a condition of authentication.
+- Signal-less users receive an optional, non-blocking, one-time taste picker after
+  cold-start seeding finishes. It reuses bounded watchlist signals and adds the
+  additive `0005_taste_onboarding` migration.
+- Confirmed local login, Plex login, logout, and passive identity changes now form
+  one TanStack Query session boundary. Prior-user queries and mutations cannot
+  repopulate cache or UI state for the next household user, while failed auth
+  transitions preserve the confirmed session.
+- Release preparation updates development-only `pip` to 26.2.1 and the existing
+  `js-yaml` override to 4.3.1. No runtime dependency is added.
+
+## Completed verification
+
+- Final `just release-check` passed on 2026-08-22 with 490 backend tests and 98
+  frontend tests, generated API type freshness, lint and strict type checks, the
+  production frontend build, the real-backend Chromium login/home/detail/request
+  journey, and native container health, private logs, hardened headers, SPA serving,
+  non-root runtime, and volume persistence.
+- All 14 living OpenSpec specifications passed strict validation. The archived
+  `improve-rail-discovery` and `add-plex-play-and-taste-onboarding` changes are
+  included; the auth-query-cache work is a direct security bug fix with no active
+  change artifact.
+- Multiple complete reviews of the cross-user cache fix reported no blocking
+  findings, and PR #18 passed the required check, E2E, container-smoke, and CodeQL
+  jobs before squash merge.
+
+## Dependency audit
+
+- `pip-audit` reports no known vulnerabilities after updating development-tool
+  `pip` from 26.1.2 to 26.2.1. The local Tasterr package is skipped because it is
+  not a PyPI distribution.
+- `npm audit` reports no known vulnerabilities after updating the existing
+  development-only `js-yaml` override from 4.3.0 to 4.3.1. The package remains
+  transitive through Redocly and `openapi-typescript` and is absent from the runtime
+  image.
+
+## Security review
+
+- The complete diff since v1.0.2 was reviewed against `docs/SECURITY.md`. The new
+  onboarding endpoints retain session authentication, same-origin mutation guards,
+  rate limiting, bounded typed inputs, and explicit secret-free responses.
+- Only `clients/seerr.py` reads the additional upstream playback fields. The backend
+  accepts credential-free `https://app.plex.tv` and bounded `plex://preplay/`
+  targets, rejects token-bearing or malformed links, and adds no direct Plex HTTP.
+- The cross-user cache fix cancels prior-session queries before removal, invalidates
+  mutation callbacks with a per-QueryClient epoch, and publishes only confirmed auth
+  state. Tests cover local and Plex login, logout, passive cookie identity changes,
+  late query and mutation completion, and failed auth transitions.
+- The `0005` migration adds one non-secret onboarding boolean. No household title
+  data, token, credential, internal URL, or raw upstream response is logged or added
+  to repository fixtures.
+- Public repository controls remain enabled, including private vulnerability
+  reporting, secret scanning with push protection, and protected immutable version
+  tags; artifact attestations and immutable GitHub Releases are enabled.
+
+## Live-contract disposition
+
+At the release owner's direction, the automated live Seerr contract suite was not
+rerun. The owner manually exercised the new Tasterr build before release and does
+not require another live-app pass for this release. This is recorded as an explicit
+exception because the release changes authentication/session and Seerr-facing
+behavior, so the ordinary unchanged-surface waiver does not apply.
+
+## Upgrade and rollback
+
+- Back up the SQLite database before upgrading. Startup applies the additive `0005`
+  migration; existing users with taste signals remain completed, while signal-less
+  users may receive the optional picker.
+- Rollback to v1.0.2 requires restoring the matching pre-upgrade database backup if
+  the older application cannot tolerate the migrated schema.
+
+## Known limitations
+
+- Plex handoffs remain experimental because Plex clients can discard a requested
+  title during sign-in or household-user selection; Tasterr cannot repair that
+  cross-origin client state without prohibited Plex-token/API access.
+- A shared browser profile still has one cookie jar across tabs. Passive `auth/me`
+  refreshes isolate cache on detected identity changes, but concurrent tabs cannot
+  carry independent household sessions.
+- Tasterr remains a single-process household service; multiple workers are not
+  supported.
+- A non-failing TestClient deprecation remains scheduled for dependency maintenance.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "frontend",
-	"version": "1.0.2",
+	"version": "1.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "1.0.2",
+			"version": "1.1.0",
 			"dependencies": {
 				"@tailwindcss/vite": "^4.3.2",
 				"@tanstack/react-query": "^5.101.2",
@@ -1852,9 +1852,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "1.0.2",
+	"version": "1.1.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",
@@ -37,7 +37,7 @@
 	},
 	"overrides": {
 		"@redocly/openapi-core@1.34.17": {
-			"js-yaml": "4.3.0"
+			"js-yaml": "4.3.1"
 		}
 	}
 }


### PR DESCRIPTION
## What / why

Prepares Tasterr v1.1.0 with version metadata, operator documentation, and pre-tag evidence for every change since v1.0.2: broader and clearer rail discovery, validated Plex playback handoffs and taste onboarding, and cross-user query-cache isolation. Refreshes only the development-tool lock entries for pip 26.2.1 and js-yaml 4.3.1 so both ecosystem audits are clean. Records the completed release gates and the release owner's decision to rely on prior manual validation instead of rerunning the live Seerr contract suite.

## Spec

- OpenSpec change: `n/a: release preparation`
- [x] Change archived on this branch (not applicable: included feature changes are already archived)

## Checklist

- [x] `just check` passes locally
- [x] Title is the Conventional Commit subject for the squash
