### PR TITLE
chore: prepare v2.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,8 @@ low-correlation picks keep discovery broad. These features need no Plex URL or t
 configuration: they reuse the encrypted token created by Plex sign-in and disappear
 cleanly for local sessions or when Plex is unavailable.
 
-Tasterr intentionally does not bundle Seerr, start or control playback, persist raw history
-or Plex progress, persist household groups, or run more than one process. The
-Plex-aware source change and its later `v2.0.0` image/tag release
-are separate review steps; the published-image example below remains pinned to the
-latest released line.
+Tasterr intentionally does not bundle Seerr, start or control playback, persist raw
+history or Plex progress, persist household groups, or run more than one process.
 
 ## Screenshots
 
@@ -86,7 +83,7 @@ values listed above. Pin the desired version from the
 ```yaml
 services:
   tasterr:
-    image: ghcr.io/zacharyarthur/tasterr:1.1.0
+    image: ghcr.io/zacharyarthur/tasterr:2.0.0
     restart: unless-stopped
     ports:
       - "127.0.0.1:8000:8000"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,10 @@
 
 | Version | Supported |
 |---|---|
-| 1.0.x | Yes |
+| 2.0.x | Yes |
 | Pre-release and older builds | No |
 
-Security fixes are made on the current stable 1.0 line. Upgrade to the newest patch
+Security fixes are made on the current stable 2.0 line. Upgrade to the newest patch
 release before reporting an issue that may already be fixed.
 
 ## Report a vulnerability privately

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tasterr"
-version = "1.1.0"
+version = "2.0.0"
 description = "Self-hosted, Netflix-style discovery front-end for a household media stack"
 license = "AGPL-3.0-only"
 requires-python = ">=3.13"

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -373,8 +373,8 @@ def test_same_origin_and_headerless_polls_still_complete_login(tmp_path: Path) -
     passes (non-browser client — CSRF is a browser attack), same-site rejects."""
     harness = _harness(tmp_path)
 
-    # same-origin completes.
     with TestClient(harness.app) as client:
+        # same-origin completes.
         handle = _start_pin_login(client)
         harness.plex.token = PLEX_TOKEN
         same_origin = _poll_pin(client, handle, **{"Sec-Fetch-Site": "same-origin"})
@@ -382,24 +382,21 @@ def test_same_origin_and_headerless_polls_still_complete_login(tmp_path: Path) -
         assert same_origin.json()["status"] == "ok"
         assert "tasterr_session=" in same_origin.headers["set-cookie"]
 
-    # none (user-initiated, e.g. typed address bar) completes.
-    with TestClient(harness.app) as client:
+        # none (user-initiated, e.g. typed address bar) completes.
         handle = _start_pin_login(client)
         harness.plex.token = PLEX_TOKEN
         none_site = _poll_pin(client, handle, **{"Sec-Fetch-Site": "none"})
         assert none_site.status_code == 200
         assert none_site.json()["status"] == "ok"
 
-    # headerless non-browser client completes (the existing default behavior).
-    with TestClient(harness.app) as client:
+        # headerless non-browser client completes (the existing default behavior).
         handle = _start_pin_login(client)
         harness.plex.token = PLEX_TOKEN
         headerless = _poll_pin(client, handle)
         assert headerless.status_code == 200
         assert headerless.json()["status"] == "ok"
 
-    # same-site is rejected (sibling origin to a registrable domain).
-    with TestClient(harness.app) as client:
+        # same-site is rejected (sibling origin to a registrable domain).
         handle = _start_pin_login(client)
         harness.plex.token = PLEX_TOKEN
         same_site = _poll_pin(client, handle, **{"Sec-Fetch-Site": "same-site"})

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -56,7 +56,7 @@ def test_readme_links_every_living_operator_document() -> None:
     assert "A shared Docker network is not required" in readme
     assert "TASTERR_HTTP_PORT=8000" in readme
     assert "github.com/ZacharyArthur/tasterr/actions/workflows/gate.yml/badge.svg" in readme
-    assert "image: ghcr.io/zacharyarthur/tasterr:1.1.0" in readme
+    assert "image: ghcr.io/zacharyarthur/tasterr:2.0.0" in readme
     assert '- "127.0.0.1:8000:8000"' in readme
     assert "tasterr-data:/data" in readme
     assert "does not require a\n`.env` file" in readme
@@ -81,12 +81,12 @@ def test_readme_links_every_living_operator_document() -> None:
     assert "This is a Compose concern, not an application requirement" in configuration
 
     releasing = _read(DOCS / "RELEASING.md")
-    evidence = _read(DOCS / "releases" / "v1.1.0.md")
+    evidence = _read(DOCS / "releases" / "v2.0.0.md")
     assert "OWNER/REPOSITORY" not in readme + releasing + evidence
     assert "empty **public** `ZacharyArthur/tasterr` repository" in releasing
     assert "`check`, `e2e`, `container-smoke`, and `CodeQL`" in releasing
     assert "leave the existing `sha-<full-commit>` candidate unchanged" in releasing
-    assert "pin the `1.1.0` digest" in releasing
+    assert "pin the `2.0.0` digest" in releasing
     assert "GitHub Release is the authoritative post-tag record" in releasing
     assert "do not create a post-release evidence commit" in releasing
     assert "do not move, delete, or reuse the published tag" in releasing
@@ -141,7 +141,7 @@ def test_release_check_is_deterministic_and_keeps_external_checks_explicit() -> 
     assert "just release-check" in releasing
     assert "just audit" in releasing
     assert "just test-live" in releasing
-    assert "v1.1.0" in releasing
+    assert "v2.0.0" in releasing
     assert "archive <change-id>" in releasing
 
 
@@ -149,7 +149,7 @@ def test_public_security_policy_is_private_and_actionable() -> None:
     policy = _read(ROOT / "SECURITY.md")
     engineering = _read(DOCS / "SECURITY.md")
 
-    assert "1.0.x" in policy
+    assert "2.0.x" in policy
     assert "Security → Advisories → Report a vulnerability" in policy
     assert "Do not open a public issue" in policy
     assert "three business days" in policy
@@ -167,10 +167,10 @@ def test_plex_operator_docs_cover_privacy_recovery_and_release_order() -> None:
     for term in (
         "need no Plex URL or token",
         "Continue Watching",
-        "raw history",
-        "separate review steps",
+        "encrypted token created by Plex sign-in",
     ):
         assert term in readme
+    assert re.search(r"persist raw\s+history", readme)
     for term in (
         "No application environment variable is added",
         "Upgrade Matching",
@@ -178,7 +178,7 @@ def test_plex_operator_docs_cover_privacy_recovery_and_release_order() -> None:
         "Manage Library Access",
         "downgrade to `0005`",
         "TASTERR_LIVE_PLEX_OWNER_TOKEN",
-        "separate release change",
+        "Every v2.0 release candidate",
     ):
         assert term in configuration
     for term in (

--- a/backend/tests/test_release_version.py
+++ b/backend/tests/test_release_version.py
@@ -6,14 +6,14 @@ from pathlib import Path
 from pydantic import BaseModel
 
 ROOT = Path(__file__).resolve().parents[2]
-VERSION = "1.1.0"
+VERSION = "2.0.0"
 
 
 class PackageManifest(BaseModel):
     version: str
 
 
-def test_package_and_lock_metadata_are_v1() -> None:
+def test_package_and_lock_metadata_are_v2() -> None:
     pyproject = (ROOT / "backend" / "pyproject.toml").read_text(encoding="utf-8")
     uv_lock = (ROOT / "backend" / "uv.lock").read_text(encoding="utf-8")
     frontend = PackageManifest.model_validate_json(
@@ -29,7 +29,7 @@ def test_package_and_lock_metadata_are_v1() -> None:
     assert frontend_lock.version == VERSION
 
 
-def test_image_workflow_maps_v1_tag_to_release_aliases() -> None:
+def test_image_workflow_maps_v2_tag_to_release_aliases() -> None:
     image = (ROOT / ".github" / "workflows" / "image.yml").read_text(encoding="utf-8")
 
     assert 'tags:\n      - "v*"' in image
@@ -41,7 +41,7 @@ def test_image_workflow_maps_v1_tag_to_release_aliases() -> None:
 
 def test_release_documents_name_the_current_stable_tag() -> None:
     releasing = (ROOT / "docs" / "RELEASING.md").read_text(encoding="utf-8")
-    evidence = (ROOT / "docs" / "releases" / "v1.1.0.md").read_text(encoding="utf-8")
+    evidence = (ROOT / "docs" / "releases" / "v2.0.0.md").read_text(encoding="utf-8")
 
     assert f"package version is\n`{VERSION}`" in releasing
     assert f"Git tag is `v{VERSION}`" in releasing

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "tasterr"
-version = "1.1.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -235,9 +235,8 @@ docker compose run --rm --no-deps --entrypoint python tasterr -c "from alembic i
 docker compose up -d --no-build
 ```
 
-The implementation change does not publish `v2.0.0`; version metadata, image/tag
-publication, live release verification, and rollback rehearsal happen in a
-separate release change.
+The `v2.0.0` release uses this downgrade sequence for any return to v1.1. An
+image-only rollback across migration `0006` is unsupported.
 
 ## Live contract verification
 
@@ -246,8 +245,9 @@ Live Plex/Seerr contracts are opt-in and excluded from `just check` and CI. Put 
 outside the repository, restrict that file to the current user, load it only into
 the devcontainer shell, and run `just test-live`. Owner, managed, and shared Plex
 tokens are supplied as `TASTERR_LIVE_PLEX_OWNER_TOKEN`,
-`TASTERR_LIVE_PLEX_MANAGED_TOKEN`, and `TASTERR_LIVE_PLEX_SHARED_TOKEN`; omit a role
-only when it is genuinely unavailable and record the skip generically.
+`TASTERR_LIVE_PLEX_MANAGED_TOKEN`, and `TASTERR_LIVE_PLEX_SHARED_TOKEN`. All three
+are required for the five-test Plex suite; if any is unavailable, the complete suite
+skips and the release record must state that generically.
 
 ```console
 chmod 600 /tmp/tasterr-live.env
@@ -256,8 +256,9 @@ npx @devcontainers/cli exec --workspace-folder . bash -lc 'set -a; . /tmp/taster
 
 Never put live values in `.env.example`, the repository, command output, test
 fixtures, or evidence. Record only versions and generic exercised/skipped/pass/fail
-results. The source implementation must pass its live contracts and full gate before
-archive; `v2.0.0` release verification remains a later step.
+results. Every v2.0 release candidate must pass these live contracts and the full
+release gate before tagging, or record the narrow release-owner exception in
+[RELEASING.md section 5](RELEASING.md#5-run-live-seerr-and-plex-contracts).
 
 ## Troubleshooting
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,12 +1,8 @@
 # Releasing
 
-This procedure is for stable v1 releases. The current package version is
-`1.1.0`, its Git tag is `v1.1.0`, and its image is published by the `image` workflow
-only after all release changes are squash-merged to protected `main`. The published
-`v1.0.0` tag is retained for provenance, but no GitHub Release was announced for it;
-`v1.0.1` is the immutable-tag fix-forward and first announced release.
-The v1.0.1 image and GitHub Release predate image attestations and immutable GitHub
-Releases; those guarantees apply to later publications.
+This procedure is for stable releases. The current package version is
+`2.0.0`, its Git tag is `v2.0.0`, and its image is published by the `image` workflow
+only after all release changes are squash-merged to protected `main`.
 
 ## 1. Prepare the required devcontainer
 
@@ -46,11 +42,11 @@ native image/Compose smoke sequentially. Any failure blocks the release.
 npx @devcontainers/cli exec --workspace-folder . just release-check
 ```
 
-Record the date and result in `docs/releases/v1.1.0.md`. This command intentionally
+Record the date and result in `docs/releases/v2.0.0.md`. This command intentionally
 does not imply that audits, security review, or live contracts passed.
 
-For subsequent releases, the committed evidence file is the pre-tag record. Write
-it so it remains true after publication: use an `approved for release` disposition,
+The committed evidence file is the pre-tag record. Write it so it remains true after
+publication: use an `approved for release` disposition,
 not a pending post-tag state, and do not predict a manifest digest or publication
 time. The GitHub Release is the authoritative post-tag record for the final digest
 and post-tag smoke results.
@@ -68,32 +64,32 @@ finding only when its advisory identifier, affected surface, and concise rationa
 are recorded in the release evidence. Never copy audit output containing private
 registry coordinates or environment data into the repository.
 
-## 5. Run live Seerr contracts
+## 5. Run live Seerr and Plex contracts
 
 Create `/tmp/tasterr-live.env` inside the devcontainer with mode `600`; never place it
 under the repository. It must supply the live Seerr URL, local account email/password,
-Seerr API key, a stored Plex token, and a disposable movie identifier that the account
-may request. An optional known-available movie identifier enables the data-dependent
-availability case. Then run:
+Seerr API key, a stored Plex token accepted by Seerr, a disposable movie identifier
+that the account may request, and the owner/managed/shared Plex tokens documented in
+`backend/tests/live/test_plex_live.py`. An optional known-available movie identifier
+enables the data-dependent availability case. Then run:
 
 ```console
 npx @devcontainers/cli exec --workspace-folder . bash -lc 'set -a; . /tmp/tasterr-live.env; set +a; just test-live'
 ```
 
-The mandatory v1.0 cases are local auth, invalid-session status, stored-Plex-token
-auth, availability read, request-history read, and request-as-user attribution. The
-request case creates a real Seerr request and attempts cleanup, so choose a disposable
-title and verify cleanup afterward. Record only the Seerr version and generic passed/
-skipped case names. A deeper pagination or available-title case may be skipped only
-when its documented data precondition is absent; stored-token auth and attributed
-request may not be skipped within a performed v1.0 run.
-
-The release owner may waive a release-candidate rerun only when a complete prior v1.0
-baseline passed, the reviewed delta does not change Seerr clients, authentication or
-session behavior, request/availability contracts, or the live harness, and the
-release evidence records the baseline date/version/scope plus the waiver rationale
-without claiming a fresh pass. Any change to those surfaces invalidates the waiver.
-Remove the temporary secret file after a run.
+Mandatory Seerr cases are local auth, invalid-session status, stored-Plex-token auth,
+availability read, request-history read, and request-as-user attribution. Mandatory
+Plex cases cover owner, managed, and shared account/resource discovery, verified TLS
+and machine identity, local-account mapping, per-row history isolation, caller-scoped
+Continue Watching, merge timestamps, and canonical TMDB GUID mapping. The request
+case creates a real Seerr request and attempts cleanup, so choose a disposable title
+and verify cleanup afterward. Only a deeper pagination, available-title, or other
+explicitly documented data-precondition case may skip. Record only upstream versions
+and generic passed/skipped case names. If retained credentials have become stale, a
+release owner may accept a recent complete automated baseline plus a fresh integrated
+manual test only for a release-only delta; record the baseline and, where a rerun was
+attempted, its generic failed phase, plus the explicit exception without claiming a
+fresh automated pass. Remove every temporary secret file after the run.
 
 ## 6. Validate and archive any OpenSpec change
 
@@ -181,8 +177,9 @@ commit-addressed `sha-<full-commit>` candidate tags. Before tagging:
    commit-SHA
    `ghcr.io/zacharyarthur/tasterr:sha-<full-commit>` candidate. Verify health, SPA
    serving, non-root uid, and named-volume persistence across recreation.
-4. Remove the disposable project, volume, network, and secret file. Record the
-   manifest digest and generic result in the release evidence.
+4. Remove the disposable project, volume, network, and secret file. Keep the manifest
+   digest and generic result for the GitHub Release; do not commit them to the
+   repository.
 
 Documentation-only pushes under `docs/` or to `README.md` do not trigger the image
 workflow. A release-preparation merge must include the package-version changes in
@@ -195,43 +192,42 @@ pushes.
 After every pre-tag release-record field is final, create and push the annotated tag:
 
 ```console
-npx @devcontainers/cli exec --workspace-folder . git tag -a v1.1.0 -m "v1.1.0"
-npx @devcontainers/cli exec --workspace-folder . git push origin v1.1.0
+npx @devcontainers/cli exec --workspace-folder . git tag -a v2.0.0 -m "v2.0.0"
+npx @devcontainers/cli exec --workspace-folder . git push origin v2.0.0
 ```
 
-Wait for the image workflow. It must publish `1.1.0`, `1.1`, `1`, and `latest`, and
+Wait for the image workflow. It must publish `2.0.0`, `2.0`, `2`, and `latest`, and
 leave the existing `sha-<full-commit>` candidate unchanged. Inspect the stable
 manifest and confirm both platforms:
 
 ```console
-npx @devcontainers/cli exec --workspace-folder . docker buildx imagetools inspect ghcr.io/zacharyarthur/tasterr:1.1.0
+npx @devcontainers/cli exec --workspace-folder . docker buildx imagetools inspect ghcr.io/zacharyarthur/tasterr:2.0.0
 ```
 
-The historical v1.0.1 image has no attestation. For subsequent releases, substitute
-the release version and verify the stable image attestation:
+Verify the stable image attestation:
 
 ```console
-gh attestation verify oci://ghcr.io/zacharyarthur/tasterr:<version> -R ZacharyArthur/tasterr
+gh attestation verify oci://ghcr.io/zacharyarthur/tasterr:2.0.0 -R ZacharyArthur/tasterr
 ```
 
 Perform a fresh install in an empty directory with a new external network, disposable
 `.env`, and new Compose project. Set
-`TASTERR_IMAGE=ghcr.io/zacharyarthur/tasterr:1.1.0`, run `docker compose pull` and
+`TASTERR_IMAGE=ghcr.io/zacharyarthur/tasterr:2.0.0`, run `docker compose pull` and
 `docker compose up -d --no-build`, then verify health, SPA serving, non-root uid, and
 named-volume persistence. Delete every disposable resource after verification.
 
 Publish release notes only after the applicable manifest, attestation, and fresh
 install checks pass. Summarize user-visible changes, upgrade steps, and known
-limitations; then pin the `1.1.0` digest as the released artifact without reproducing
-private evidence. The historical v1.0.1 GitHub Release is mutable. Publish v1.1.0
-with repository immutability enabled only after `1.1.0`, `1.1`, `1`, and `latest`
+limitations; then pin the `2.0.0` digest as the released artifact without reproducing
+private evidence. Publish v2.0.0 with repository immutability enabled only after
+`2.0.0`, `2.0`, `2`, and `latest`
 resolve to the expected release commit, the `sha-<full-commit>` candidate retains its
 recorded pre-tag digest, and the tagged clean-install smoke passes.
 
-For subsequent releases, do not create a post-release evidence commit. Record the
-final digest, publication time, alias verification, and tagged-image smoke only in
-the GitHub Release. This avoids advancing `main` and publishing a new candidate
-image solely to describe the release that preceded it.
+After publication, do not create a post-release evidence commit. Record the final
+digest, publication time, alias verification, and tagged-image smoke only in the
+GitHub Release. This avoids advancing `main` and publishing a new candidate image
+solely to describe the release that preceded it.
 
 If any post-tag check fails, do not move, delete, or reuse the published tag.
 Document the failure, fix forward through the normal protected-`main` workflow, and
@@ -248,5 +244,6 @@ documented in [CONFIGURATION.md](CONFIGURATION.md). To roll back an image-only c
 set `TASTERR_IMAGE` to the preceding known-good digest and force-recreate the service
 against the existing volume. If a migration is not backward-compatible, stop the
 writer and restore the matching pre-upgrade backup before starting the old digest.
-Version 1.0's M6 change has no migration, so its rollback basis is the prior image
-digest with the same database file.
+Version 2.0 includes migration `0006`. To return to v1.1, use the v2 image to
+downgrade to `0005` before starting the old image, or restore the validated matching
+pre-upgrade backup. Do not start a v1.1 image directly on the v2 database.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -147,10 +147,13 @@ relevant checklists below (enforced via `openspec/config.yaml` rules).
 
 - [ ] `just audit` clean, or findings triaged with reasons in the PR.
 - [ ] Security review pass over the full diff since the last tag.
-- [ ] Live contract tests against the home Seerr instance pass; tested Seerr version recorded.
+- [ ] Live contract tests against the home Seerr instance pass and the tested Seerr
+      version is recorded, or the narrow release-owner exception in
+      [RELEASING.md section 5](RELEASING.md#5-run-live-seerr-and-plex-contracts) is recorded.
 - [ ] Opt-in Plex contracts pass for every available owner/managed/shared role with
       standard TLS, machine identity, per-row history identity, account-scoped
-      Continue Watching, and TMDB GUID mapping; evidence is redacted.
+      Continue Watching, and TMDB GUID mapping with redacted evidence, or the same
+      narrow release-owner exception is recorded.
 - [ ] `.env.example` contains placeholders only — no real values, no real hostnames.
 
 - [ ] `just release-check` passes in the devcontainer (ordinary gate + browser +

--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -1,0 +1,142 @@
+# Tasterr v2.0.0 release evidence
+
+- Release date: 2026-08-29
+- Git tag: `v2.0.0`
+- Evidence status: approved for release after the automated controls and documented
+  live-contract exception below. The immutable GitHub Release will be the
+  authoritative record for the final manifest digest, publication time, alias
+  verification, and tagged-image smoke result.
+
+## Scope
+
+- Plex-backed sessions import bounded canonical watch facts into per-user taste
+  profiles and expose caller-scoped Continue Watching without persisting raw history,
+  progress, account/server identifiers, URLs, or resource tokens.
+- Server discovery accepts only verified HTTPS `plex.direct` connections, validates
+  unauthenticated machine identity, never follows redirects, keeps credentials in
+  headers, and isolates owner, managed, and shared account history.
+- Home adds low-correlation **Picks You Wouldn't Usually Watch**, an ephemeral
+  caller-inclusive **Something for Everyone Tonight** blend, progress/context on
+  resume cards, and the reviewed personalized/service/decade/genre rail order.
+- Concurrent bounded Plex connection discovery and a ten-second Continue Watching
+  deadline make healthy late-priority connections usable without weakening TLS,
+  machine-identity, redirect, or credential controls.
+- Migration `0006` adds Plex history attempt/success timestamps and the canonical
+  `watched_plex` signal index. Its downgrade invalidates affected profile caches,
+  removes v2 data, restores the prior index, and strips only v2 rail ids.
+- Release preparation changes package/documentation version metadata to `2.0.0` and
+  adds no runtime behavior, dependency, database, API, or workflow change.
+
+## Completed verification
+
+- Final `just release-check` passed on 2026-08-28 with 634 backend tests and 106
+  frontend tests, generated API type freshness, lint and strict type checks, the
+  production frontend build, one real-backend Chromium login/home/detail/request
+  journey, and native container health, private logs, hardened headers, SPA serving,
+  non-root runtime, and named-volume persistence.
+- Final branch `just check` passed on 2026-08-29 with 634 backend tests, 106
+  frontend tests, generated API type freshness, lint and strict type checks, and the
+  production frontend build.
+- Strict OpenSpec validation passed for `v2-release-readiness`; its five modified
+  requirements were synced into the living spec and the completed change was
+  archived on this branch.
+- The Plex-aware product PR #20 passed required check, E2E, container-smoke, and
+  CodeQL jobs before squash merge. Its main/SHA candidate image build and attestation
+  also passed.
+
+## Dependency audit
+
+- `pip-audit` reports no known vulnerabilities in the frozen backend environment.
+  The local `tasterr` 2.0.0 package is skipped because it is not a PyPI distribution.
+- `npm audit` reports no known vulnerabilities in the frozen frontend lockfile.
+
+## Security review
+
+- The complete `v1.1.0..HEAD` scope was reviewed against `docs/SECURITY.md` with no
+  release-blocking finding. API/session/mutation boundaries remain authenticated,
+  rate-limited, CSRF-checked, explicitly modeled, and covered by secret-projection
+  and mutation-inventory regressions.
+- Plex outbound handling remains bounded and fail-closed: allowlisted HTTPS hosts,
+  normal TLS verification, unauthenticated exact-machine identity checks, disabled
+  redirects, header-only credentials, caller/account filtering, bounded deadlines,
+  and cancellation all retain focused regressions.
+- Migration `0006` is additive on upgrade. Its tested downgrade invalidates affected
+  profile caches, removes v2 watch signals, restores the prior unique index, drops
+  the v2 timestamps, and removes only v2 rail ids before a v1.1 image may start.
+- Frontend review found no secret-bearing storage or response projection; household
+  blending remains ephemeral and caller-scoped. Release evidence and logs contain
+  generic outcomes only.
+- Focused workflow, documentation, secret-projection, mutation-inventory, and
+  container-contract regressions passed (26 tests). They pin full-SHA Actions,
+  least-privilege workflow permissions, placeholder fixtures, public API secret
+  boundaries, source/license coordinates, and release-document controls.
+- GitHub verification confirmed the public repository, private vulnerability
+  reporting, secret scanning with push protection, Dependabot alerts/security
+  updates, active protected-main and immutable-release-tag rulesets, and that
+  immutable GitHub Releases are enabled. The GHCR `main` manifest is anonymously
+  readable and the public package page links to `ZacharyArthur/tasterr`.
+- No generated Playwright report, trace, HAR, or log artifact is tracked or staged.
+  The local hermetic E2E outputs under `frontend/playwright-report/` and
+  `frontend/test-results/` are gitignored and were reviewed without finding live
+  credentials, private URLs, identities, or household viewing data.
+- The image workflow retains artifact attestations and confines package,
+  attestation, and OIDC write permissions to its publish job.
+- The release-prep diff changes only version metadata, public documentation,
+  documentation/version regressions, and OpenSpec evidence. It adds no runtime,
+  dependency, database, API, or workflow change. The documented candidate/tag
+  runbook records post-merge facts in the immutable GitHub Release and requires no
+  post-release source commit.
+
+## Live-contract disposition
+
+- The complete automated Seerr 3.3.0 baseline from 2026-07-13 passed ten live cases
+  with no skips. The release environment no longer retained the local credentials
+  needed for a fresh automated Seerr run.
+- That baseline predates the Seerr playback-field client change released in v1.1.0;
+  the Seerr client is unchanged in `v1.1.0..HEAD`.
+- The five-test owner/managed/shared Plex suite passed on 2026-08-27 against PMS
+  `1.43.3.10896-cb3ebc72d`. It covered account/resource discovery, verified TLS and
+  machine identity, local-account resolution, exact per-row history isolation and
+  paging, caller-scoped Continue Watching, merge timestamps, and movie plus
+  episode-to-show canonical GUID mapping.
+- A 2026-08-28 release rerun could not complete the retained owner's history phase;
+  the release owner identified the stored access as potentially stale. No token,
+  URL, identity, title, account/server identifier, or upstream payload was recorded.
+- The release owner performed a fresh integrated manual live test and explicitly
+  accepts the complete dated automated baselines for this release-only delta. This
+  is an exception, not a claim that the automated release rerun passed.
+
+## Upgrade and rollback
+
+- Before upgrading, record the running immutable digest and take and validate a
+  sensitive SQLite backup. Select `ghcr.io/zacharyarthur/tasterr:2.0.0`, pull, and
+  recreate without building; startup applies migration `0006` automatically.
+- Verify health, login, Home including Continue Watching where available, detail,
+  and one non-destructive request-state read after upgrade.
+- Do not start a v1.1 image on a v2 database. To roll back, keep the v2 image
+  selected, stop the writer, run the documented Alembic downgrade to `0005`, then
+  select the prior immutable v1.1 digest; alternatively restore the matching
+  validated pre-upgrade backup.
+
+## Known limitations
+
+- Plex items without a canonical TMDB GUID are omitted rather than title/year
+  guessed; legacy-agent libraries may need an agent upgrade and metadata refresh.
+- An inaccessible Plex share has no Tasterr allow/deny switch; remove its library
+  access in Plex. Usable sibling servers continue to contribute.
+- Leading-zero rating keys would fail closed as an identity mismatch; Plex does not
+  normally emit that non-canonical form.
+- Continue Watching performs at most twenty concurrent catalog detail resolutions;
+  the hard cap bounds work at household scale.
+- Tasterr remains a single-process household service; multiple workers are not
+  supported.
+- One non-failing Starlette/httpx2 TestClient deprecation warning remains scheduled
+  for dependency maintenance.
+
+## Post-merge and post-tag record
+
+After the release-readiness PR merges, the exact SHA candidate must pass manifest,
+attestation, public visibility, anonymous pull, and disposable clean-install checks
+before tagging. After `v2.0.0`, stable aliases, final digest, attestation, and fresh
+tagged-install results are recorded only in the immutable GitHub Release. No
+post-release source commit is created solely to record those later facts.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "frontend",
-	"version": "1.1.0",
+	"version": "2.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "1.1.0",
+			"version": "2.0.0",
 			"dependencies": {
 				"@tailwindcss/vite": "^4.3.2",
 				"@tanstack/react-query": "^5.101.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "1.1.0",
+	"version": "2.0.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/openspec/changes/archive/2026-08-29-v2-release-readiness/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-29-v2-release-readiness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-28

--- a/openspec/changes/archive/2026-08-29-v2-release-readiness/design.md
+++ b/openspec/changes/archive/2026-08-29-v2-release-readiness/design.md
@@ -1,0 +1,160 @@
+## Context
+
+The Plex-aware personalization product change is archived and merged at
+`dd183dc`. Its `main`/SHA candidate image was built and attested, but package
+metadata, the public deployment example, support policy, and stable tags remain on
+v1.1. The feature design intentionally deferred `v2.0.0` packaging and publication
+to this change so release evidence can be reviewed independently from runtime code.
+
+The existing protected-branch, immutable-tag, GHCR, attestation, and release-check
+machinery already supports the release. This change should configure and exercise
+that machinery, not add another release system.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `2.0.0` the single release version across backend/frontend metadata,
+  lockfiles, regression tests, documentation, and support policy.
+- Produce a publishable, redacted pre-tag evidence record for the complete v2 scope.
+- Run the deterministic release gate, both dependency audits, applicable security
+  review, and live Seerr plus three-role Plex contracts before tagging.
+- Merge through the normal protected PR, verify the immutable SHA candidate, then
+  publish and verify `v2.0.0`, `2.0.0`, `2.0`, `2`, and `latest` without moving tags.
+
+**Non-Goals:**
+
+- Runtime, API, migration, recommendation, Plex, Seerr, or UI behavior changes.
+- New dependencies, workflows, tag formats, registries, or release automation.
+- Storing private live coordinates, credentials, household data, or raw logs.
+- Rewriting historical v1 evidence or tags.
+
+## Decisions
+
+### 1. Reuse the existing release pipeline unchanged
+
+The release change updates only version-bearing metadata, assertions, living
+operator/release docs, the public support line, and a new evidence file. The current
+workflow already enforces SemVer tags, main ancestry, multi-architecture publication,
+stable aliases, and artifact attestations. Changing it would enlarge the security
+review without improving the v2 release.
+
+Alternative: add v2-specific workflow logic. Rejected because the existing generic
+`v*`/SemVer rules already cover major releases.
+
+### 2. Use one literal version and pin it with existing tests
+
+`2.0.0` will replace the project version in `backend/pyproject.toml`, the local
+package entry in `backend/uv.lock`, `frontend/package.json`, and the root entry in
+`frontend/package-lock.json`. The release-version and documentation regressions will
+point to `v2.0.0`, `docs/releases/v2.0.0.md`, the v2 README image, and the v2 support
+line. Dependency versions that happen to contain `1.1.0` remain untouched.
+
+Alternative: derive every document from one build-time source. Rejected because
+that introduces generation machinery for four simple, test-pinned release fields.
+
+### 3. Split committed pre-tag evidence from authoritative post-tag facts
+
+The committed `v2.0.0` record will contain outcomes known on the reviewed branch:
+release-check, audits, strict OpenSpec validation, security review, live contracts,
+upgrade/rollback, and limitations. It will say `approved for release` and will not
+predict a merged SHA, manifest digest, publication time, or tagged-image result.
+
+After the release PR merges, candidate manifest/attestation/public-install checks
+must pass before the immutable tag is created. Stable alias, final digest,
+attestation, and clean tagged-install results belong in the immutable GitHub Release,
+which is the only post-tag record. This avoids a documentation-only commit that
+would advance `main` and publish a different candidate.
+
+Alternative: commit the candidate digest after merge. Rejected because protected
+main would require another PR and generate a new SHA candidate, invalidating the
+recorded candidate.
+
+### 4. Require live evidence without misrepresenting stale credentials
+
+A fresh `just test-live` run from a mode-0600 temporary environment is the default.
+If retained credentials no longer complete that rerun, the release owner may accept
+the most recent complete automated contract baseline plus a fresh integrated manual
+test only when the release delta contains no runtime behavior change. Evidence must
+identify the baseline date/version, the generic failed rerun phase where a rerun was
+attempted, the manual test, and the explicit exception without claiming a fresh
+automated pass.
+
+This release uses the complete 2026-08-27 owner/managed/shared Plex baseline against
+PMS `1.43.3.10896-cb3ebc72d`, the complete Seerr 3.3.0 baseline from 2026-07-13, and
+the release owner's fresh manual test. A 2026-08-28 automated Plex rerun could not
+complete the owner history phase with the retained access and the owner identified
+those credentials as potentially stale. The release-readiness delta changes only
+metadata, tests, and documentation.
+
+Alternative: report the stale-access rerun as passing. Rejected because release
+evidence must distinguish measured automated results from owner-accepted exceptions.
+
+### 5. Use migration-aware v2 upgrade and rollback guidance
+
+Operators upgrade only after a validated backup and may roll back to v1.1 only by
+using the v2 image to downgrade schema `0006` to `0005` before starting the old
+image, or by restoring the matching pre-upgrade backup. README, configuration, and
+release notes must not imply an image-only rollback across this schema boundary.
+
+## Security considerations
+
+- No API, authentication, outbound HTTP, frontend rendering, or database code is
+  changed by release preparation; the corresponding runtime checklists remain
+  covered by the already-reviewed v2 implementation and the full release gate.
+- Both frozen dependency sets are audited. Any advisory must be fixed or recorded
+  with its identifier, affected surface, and explicit disposition before tagging.
+- The full diff since `v1.1.0` is reviewed against `docs/SECURITY.md`, including
+  Plex URL allowlisting, TLS and machine identity, credential isolation, log privacy,
+  browser cache isolation, migration downgrade, workflow permissions, and action
+  SHA pinning.
+- `.env.example`, fixtures, staged files, and evidence are checked for real secrets,
+  URLs, identities, viewing data, raw logs, and generated failure artifacts.
+- GitHub private vulnerability reporting, secret scanning/push protection,
+  Dependabot alerts, immutable releases, protected `main`, and the immutable `v*`
+  tag ruleset are verified before tagging.
+- Candidate and stable images must be public, multi-architecture, anonymously
+  pullable, linked to the repository, built by the existing least-privilege workflow,
+  and covered by a valid GitHub artifact attestation.
+- No dependency is added.
+- The live exception records only generic outcomes and prior public-safe versions;
+  no stale credential, URL, identity, viewing data, or upstream payload is retained.
+
+## Risks / Trade-offs
+
+- **Live integration credentials can expire during release preparation** → Prefer a
+  fresh rerun; otherwise require a complete recorded baseline, a fresh owner manual
+  test, a release-only delta, and an explicit evidence exception that does not claim
+  fresh automation.
+- **A post-merge candidate may differ from branch-local images** → Verify its exact
+  SHA tag, manifest, attestation, anonymous pull, clean deployment, non-root runtime,
+  and volume persistence before tagging.
+- **A tag-triggered workflow or smoke can fail after publication** → Never move,
+  delete, or reuse `v2.0.0`; fix forward through protected main and publish the next
+  patch version.
+- **Major-version upgrade cannot use image-only rollback** → Require a validated
+  backup and document the `0006` to `0005` downgrade order.
+
+## Migration Plan
+
+1. Update metadata, tests, README/support/release/configuration docs, and the redacted
+   `v2.0.0` evidence record on `change/v2-release-readiness`.
+2. Run strict OpenSpec validation, `just release-check`, `just audit`, live contracts,
+   repository/security review, and `git diff --check`; archive this change.
+3. Obtain approval for the exact commit and PR text, then push and merge only after
+   `check`, `e2e`, `container-smoke`, and CodeQL pass.
+4. On merged `main`, rerun `just release-check`; verify the SHA candidate manifest,
+   attestation, public visibility, anonymous pull, and disposable clean install.
+5. Create and push the annotated `v2.0.0` tag. Verify `2.0.0`, `2.0`, `2`, `latest`,
+   and the unchanged SHA candidate, then repeat attestation and clean-install smoke.
+6. Publish the immutable GitHub Release with user-visible changes, upgrade/rollback,
+   limitations, final digest, alias verification, and post-tag results.
+
+Rollback before tagging is ordinary branch/PR correction. After tagging, preserve
+the immutable tag and fix forward. Runtime rollback follows the documented schema
+downgrade or validated pre-upgrade backup restore.
+
+## Open Questions
+
+None. The version, release scope, registry coordinate, and existing workflow are
+already fixed by the archived product change and current release policy.

--- a/openspec/changes/archive/2026-08-29-v2-release-readiness/proposal.md
+++ b/openspec/changes/archive/2026-08-29-v2-release-readiness/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+The completed Plex-aware personalization milestone is merged on `main`, but the
+published stable line and operator-facing release material still identify v1.1. The
+repository now needs the separate audited release step reserved by that feature
+change before `v2.0.0` can be tagged and announced.
+
+## What Changes
+
+- Set backend, frontend, lockfile, and release-regression metadata to `2.0.0`.
+- Pin the copyable README deployment example and supported-version policy to the
+  v2.0 stable line.
+- Update the release and configuration guides for the v2 migration, downgrade,
+  candidate, stable-image, attestation, and clean-install sequence.
+- Add a redacted `v2.0.0` pre-tag evidence record covering deterministic checks,
+  dependency audits, security review, live Seerr/Plex contracts, known limitations,
+  and rollback basis.
+- After gated merge, verify the multi-architecture SHA candidate, public anonymous
+  install, and attestation before creating `v2.0.0`; then verify stable aliases and
+  publish an immutable GitHub Release.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `release-readiness`: Advance package/docs/evidence requirements from the v1 line
+  to the separately audited v2.0 release, including the Plex live-contract gate and
+  migration-aware rollback.
+
+## Non-goals
+
+- Changing runtime product behavior, API contracts, dependencies, or database
+  schema beyond the already-merged Plex-aware implementation.
+- Weakening or waiving deterministic checks, dependency audits, live contracts,
+  repository security controls, provenance verification, or clean-install smoke.
+- Recording private URLs, credentials, household identities, title/viewing data,
+  raw logs, or unredacted live evidence.
+- Moving, deleting, or reusing a published tag if any post-tag verification fails.
+
+## Impact
+
+- Metadata: backend/frontend manifests, both lockfiles, and version regression tests.
+- Documentation: README, public support policy, configuration/releasing guides, and
+  a new `docs/releases/v2.0.0.md` evidence record.
+- Delivery: protected PR gates, GHCR candidate/stable tags and attestations, the
+  immutable `v2.0.0` Git tag, and GitHub Release.
+- Milestone: publishes the founding PRD's v2 Plex-aware personalization scope as the
+  current supported stable line.

--- a/openspec/changes/archive/2026-08-29-v2-release-readiness/specs/release-readiness/spec.md
+++ b/openspec/changes/archive/2026-08-29-v2-release-readiness/specs/release-readiness/spec.md
@@ -1,10 +1,4 @@
-# release-readiness Specification
-
-## Purpose
-Define the documentation, security, verification, evidence, and publication controls
-that make a stable Tasterr release repeatable and safe to operate.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Release-facing documentation is complete and linked
 

--- a/openspec/changes/archive/2026-08-29-v2-release-readiness/tasks.md
+++ b/openspec/changes/archive/2026-08-29-v2-release-readiness/tasks.md
@@ -1,0 +1,32 @@
+## 1. Version and Release Documentation
+
+- [x] 1.1 Set backend/frontend package and lock metadata to `2.0.0`, update the
+  release-version regression, and prove unrelated dependency versions are unchanged.
+- [x] 1.2 Update README, public support policy, configuration, releasing, and
+  documentation regressions for the v2 image, migration-aware rollback, live Plex
+  gate, candidate verification, stable aliases, and immutable GitHub Release.
+- [x] 1.3 Add `docs/releases/v2.0.0.md` with redacted scope, upgrade/rollback,
+  limitations, and placeholders only for outcomes that must be measured in this
+  release change; do not predict post-merge/tag facts.
+
+## 2. Pre-Tag Verification and Evidence
+
+- [x] 2.1 Verify repository/package security controls, workflow permissions/action
+  pinning, public support/license coordinates, placeholder-only fixtures/env, and
+  absence of live/private material or generated failure artifacts.
+- [x] 2.2 Run `just release-check` inside the devcontainer and record its exact generic
+  outcome and test counts in the v2 evidence.
+- [x] 2.3 Run both locked dependency audits, resolve actionable findings or record
+  advisory-specific dispositions, and update the v2 evidence.
+- [x] 2.4 Run mandatory live Seerr and owner/managed/shared Plex contracts from a
+  mode-0600 temporary file where current credentials permit; otherwise record the
+  release owner's explicit acceptance of complete dated automated baselines plus a
+  fresh manual test without claiming a fresh automated pass.
+- [x] 2.5 Review the complete `v1.1.0..HEAD` security and migration scope, finalize the
+  approved-for-release evidence, and confirm the post-merge candidate/tag runbook is
+  executable without a post-release source commit.
+- [x] 2.6 Run strict OpenSpec validation and fix every release artifact issue.
+
+## 3. Final Quality Gate
+
+- [x] 3.1 Run `just check` inside the devcontainer and fix any failures.


### PR DESCRIPTION
## What / why

Prepare Tasterr 2.0.0 for publication by aligning backend/frontend version metadata and updating operator, security, upgrade, rollback, and release guidance for the Plex-aware major release. Add redacted release evidence covering deterministic gates, dependency audits, security review, the accepted live-contract exception, and candidate/tag verification. Archive `v2-release-readiness` so the reviewed release contract and implementation land atomically. Keep the auth header-variant regression within one app lifespan to avoid a test-only SQLite teardown/restart race exposed by CI.

## Spec

- OpenSpec change: `v2-release-readiness`
- [x] Change archived on this branch

## Checklist

- [x] `just check` passes locally
- [x] Title is the Conventional Commit subject for the squash