### PR TITLE
chore: add GitHub CLI and OpenSpec to devcontainer

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -5,6 +5,11 @@
       "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e",
       "integrity": "sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e"
     },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.1",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:94879eebb6a0e4e2f197de9f12db7427cb4a25b82d93c55239ce8c8fc394a1b4",
+      "integrity": "sha256:94879eebb6a0e4e2f197de9f12db7427cb4a25b82d93c55239ce8c8fc394a1b4"
+    },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "1.7.1",
       "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
 	"build": { "dockerfile": "Dockerfile" },
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": { "version": "24" },
-		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 	// Dependency trees live on container volumes: faster than Windows bind
 	// mounts, and host antivirus never touches (or quarantines) them.
@@ -15,7 +16,7 @@
 		// venv volume and uv cache are different filesystems; copy, don't hardlink
 		"UV_LINK_MODE": "copy"
 	},
-	"postCreateCommand": "sudo chown -R vscode:vscode backend/.venv frontend/node_modules && (cd backend && uv sync) && (cd frontend && npm ci)",
+	"postCreateCommand": "sudo chown -R vscode:vscode backend/.venv frontend/node_modules && npm install --global @fission-ai/openspec@1 && (cd backend && uv sync) && (cd frontend && npm ci)",
 	"remoteUser": "vscode",
 	"customizations": {
 		"vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 		// venv volume and uv cache are different filesystems; copy, don't hardlink
 		"UV_LINK_MODE": "copy"
 	},
-	"postCreateCommand": "sudo chown -R vscode:vscode backend/.venv frontend/node_modules && npm install --global @fission-ai/openspec@1 && (cd backend && uv sync) && (cd frontend && npm ci)",
+	"postCreateCommand": "sudo chown -R vscode:vscode backend/.venv frontend/node_modules && (cd backend && uv sync) && (cd frontend && npm ci) && npm install --global @fission-ai/openspec@1",
 	"remoteUser": "vscode",
 	"customizations": {
 		"vscode": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ in the container, full stop.
 - VS Code: "Reopen in Container". Headless / agents:
   `npx @devcontainers/cli up --workspace-folder .` once, then
   `npx @devcontainers/cli exec --workspace-folder . <command>` for everything else.
+- Run `gh auth login` once inside the container before creating the first PR.
 - `docker build` / `docker run` work inside the container via
   docker-outside-of-docker (they drive the host engine).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,8 @@ in the container, full stop.
 - VS Code: "Reopen in Container". Headless / agents:
   `npx @devcontainers/cli up --workspace-folder .` once, then
   `npx @devcontainers/cli exec --workspace-folder . <command>` for everything else.
-- Run `gh auth login` once inside the container before creating the first PR.
+- Run `gh auth login` once per container before creating a PR; re-run it after a
+  rebuild because the container home directory is ephemeral.
 - `docker build` / `docker run` work inside the container via
   docker-outside-of-docker (they drive the host engine).
 

--- a/openspec/specs/dev-tooling/spec.md
+++ b/openspec/specs/dev-tooling/spec.md
@@ -61,8 +61,8 @@ produces, failing when they have drifted out of sync.
 
 ### Requirement: Devcontainer runs the gate without host dependencies
 The repo SHALL provide a `.devcontainer/` configuration that supplies the full
-toolchain (uv, node, just) in a Linux container with the repository bind-mounted
-from the local working copy. Dependency trees (`backend/.venv`,
+toolchain (uv, node, just, GitHub CLI, OpenSpec) in a Linux container with the
+repository bind-mounted from the local working copy. Dependency trees (`backend/.venv`,
 `frontend/node_modules`) MUST live on container volumes, not the host filesystem.
 `just check` inside the devcontainer MUST be the same command and gate as on the
 host and in CI.
@@ -151,4 +151,3 @@ credentials or publish images.
 #### Scenario: Pull request cannot publish a package
 - **WHEN** untrusted pull-request code executes in CI
 - **THEN** its workflow token has no package-write permission and no publish step runs
-


### PR DESCRIPTION
## What / why

Add GitHub CLI as a locked devcontainer feature and install OpenSpec 1.x during container setup so repository workflows stay inside the supported environment. Install project dependencies before the global OpenSpec step, document that GitHub authentication is per container, and keep the living dev-tooling spec aligned.

## Spec

- OpenSpec change: `n/a: devcontainer tooling chore`
- [x] Change archived on this branch (not applicable: chore)

## Checklist

- [x] `just check` passes locally
- [x] Title is the Conventional Commit subject for the squash
