### PR TITLE
fix: make Plex approval fallback reachable

### DIFF
--- a/frontend/src/routes/Login.test.tsx
+++ b/frontend/src/routes/Login.test.tsx
@@ -12,6 +12,7 @@ afterEach(() => {
 	cleanup();
 	vi.restoreAllMocks();
 	vi.unstubAllGlobals();
+	Reflect.deleteProperty(document, "execCommand");
 });
 
 type Route = (init?: RequestInit) => { status: number; body: unknown };
@@ -91,6 +92,8 @@ test("plex flow protects and closes its approval window after polling succeeds",
 	const { approval, close, focus, replace } = fakeApprovalWindow();
 	const open = vi.fn(() => approval);
 	vi.stubGlobal("open", open);
+	const writeText = vi.fn(() => Promise.resolve());
+	vi.stubGlobal("navigator", { clipboard: { writeText } });
 	const parentFocus = vi.mocked(window.focus);
 	const queryClient = new QueryClient({
 		defaultOptions: { queries: { retry: false } },
@@ -101,6 +104,9 @@ test("plex flow protects and closes its approval window after polling succeeds",
 	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
 
 	await screen.findByText("Waiting for Plex approval…");
+	expect(
+		screen.getByRole("link", { name: "Open the approval page" }),
+	).toBeTruthy();
 	expect(open).toHaveBeenCalledWith(
 		"",
 		"_blank",
@@ -109,6 +115,9 @@ test("plex flow protects and closes its approval window after polling succeeds",
 	expect(approval.opener).toBeNull();
 	expect(focus).toHaveBeenCalledOnce();
 	expect(replace).toHaveBeenCalledWith("https://app.plex.tv/auth#?x");
+	fireEvent.click(screen.getByRole("button", { name: "Copy approval URL" }));
+	expect(await screen.findByText("Approval URL copied.")).toBeTruthy();
+	expect(writeText).toHaveBeenCalledWith("https://app.plex.tv/auth#?x");
 	// First poll answers pending; the 2s refetch interval must fire again.
 	await vi.waitFor(() => expect(polls).toBeGreaterThanOrEqual(2), {
 		timeout: 5000,
@@ -266,6 +275,16 @@ test("plex flow shows a reachable approval link after popup blocking", async () 
 		"open",
 		vi.fn(() => null),
 	);
+	const execCommand = vi.fn(() => {
+		expect((document.activeElement as HTMLTextAreaElement).value).toBe(
+			"https://app.plex.tv/auth#?x",
+		);
+		return true;
+	});
+	Object.defineProperty(document, "execCommand", {
+		configurable: true,
+		value: execCommand,
+	});
 	renderLogin();
 
 	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
@@ -275,11 +294,60 @@ test("plex flow shows a reachable approval link after popup blocking", async () 
 	expect((link as HTMLAnchorElement).target).toBe("_blank");
 	expect((link as HTMLAnchorElement).rel).toBe("noopener noreferrer");
 	expect(
-		screen.getByRole("button", { name: "Copy approval URL" }),
+		screen
+			.getByText(/We couldn't open the Plex window/)
+			.closest("[aria-live]")
+			?.getAttribute("aria-live"),
+	).toBe("polite");
+	const copyButton = screen.getByRole("button", {
+		name: "Copy approval URL",
+	});
+	copyButton.focus();
+	fireEvent.click(copyButton);
+	expect(await screen.findByText("Approval URL copied.")).toBeTruthy();
+	expect(execCommand).toHaveBeenCalledWith("copy");
+	expect(document.activeElement).toBe(copyButton);
+});
+
+test("plex flow reports when both clipboard paths fail", async () => {
+	stubFetch({
+		"POST /api/v1/auth/plex/pin": () => ({
+			status: 200,
+			body: {
+				pin_id: "opaque-handle",
+				auth_url: "https://app.plex.tv/auth#?x",
+			},
+		}),
+		"POST /api/v1/auth/plex/pin/poll": () => ({
+			status: 200,
+			body: { status: "pending", user: null },
+		}),
+	});
+	vi.stubGlobal("navigator", {
+		clipboard: { writeText: vi.fn(() => Promise.reject(new Error("denied"))) },
+	});
+	Object.defineProperty(document, "execCommand", {
+		configurable: true,
+		value: vi.fn(() => false),
+	});
+	vi.stubGlobal(
+		"open",
+		vi.fn(() => null),
+	);
+	renderLogin();
+
+	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
+	await screen.findByRole("button", { name: "Copy approval URL" });
+	fireEvent.click(screen.getByRole("button", { name: "Copy approval URL" }));
+
+	expect(
+		await screen.findByText(
+			"Could not copy the approval URL. Use the approval link instead.",
+		),
 	).toBeTruthy();
 });
 
-test("plex flow centers a new approval window for each attempt", () => {
+test("plex flow centers the approval window in the current browser window", async () => {
 	stubFetch({
 		"POST /api/v1/auth/plex/pin": () => ({ status: 503, body: {} }),
 	});
@@ -299,6 +367,9 @@ test("plex flow centers a new approval window for each attempt", () => {
 		"_blank",
 		"width=600,height=700,left=1700,top=250",
 	);
+	expect(
+		await screen.findByText("Could not reach Plex — try again."),
+	).toBeTruthy();
 });
 
 test("plex flow can complete after the user closes the approval window", async () => {

--- a/frontend/src/routes/Login.test.tsx
+++ b/frontend/src/routes/Login.test.tsx
@@ -103,8 +103,8 @@ test("plex flow protects and closes its approval window after polling succeeds",
 	await screen.findByText("Waiting for Plex approval…");
 	expect(open).toHaveBeenCalledWith(
 		"",
-		"tasterr-plex-auth",
-		"popup=yes,width=600,height=700,scrollbars=yes,resizable=yes",
+		"_blank",
+		expect.stringMatching(/^width=600,height=700,left=-?\d+,top=-?\d+$/),
 	);
 	expect(approval.opener).toBeNull();
 	expect(focus).toHaveBeenCalledOnce();
@@ -248,7 +248,7 @@ test("plex flow can complete when the approval window is blocked", async () => {
 	);
 });
 
-test("plex flow reopens a protected approval window after popup blocking", async () => {
+test("plex flow shows a reachable approval link after popup blocking", async () => {
 	stubFetch({
 		"POST /api/v1/auth/plex/pin": () => ({
 			status: 200,
@@ -262,29 +262,43 @@ test("plex flow reopens a protected approval window after popup blocking", async
 			body: { status: "pending", user: null },
 		}),
 	});
-	const { approval, close, replace } = fakeApprovalWindow();
-	const open = vi
-		.fn<() => Window | null>()
-		.mockReturnValueOnce(null)
-		.mockReturnValueOnce(approval);
+	vi.stubGlobal(
+		"open",
+		vi.fn(() => null),
+	);
+	renderLogin();
+
+	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
+
+	const link = await screen.findByRole("link", { name: "open it here" });
+	expect((link as HTMLAnchorElement).href).toBe("https://app.plex.tv/auth#?x");
+	expect((link as HTMLAnchorElement).target).toBe("_blank");
+	expect((link as HTMLAnchorElement).rel).toBe("noopener noreferrer");
+	expect(
+		screen.getByRole("button", { name: "Copy approval URL" }),
+	).toBeTruthy();
+});
+
+test("plex flow centers a new approval window for each attempt", () => {
+	stubFetch({
+		"POST /api/v1/auth/plex/pin": () => ({ status: 503, body: {} }),
+	});
+	vi.spyOn(window, "screenX", "get").mockReturnValue(1400);
+	vi.spyOn(window, "screenY", "get").mockReturnValue(100);
+	vi.spyOn(window, "outerWidth", "get").mockReturnValue(1200);
+	vi.spyOn(window, "outerHeight", "get").mockReturnValue(1000);
+	const { approval } = fakeApprovalWindow();
+	const open = vi.fn(() => approval);
 	vi.stubGlobal("open", open);
 	renderLogin();
 
 	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
-	fireEvent.click(
-		await screen.findByRole("button", { name: "Reopen the approval page" }),
-	);
 
-	expect(open).toHaveBeenNthCalledWith(
-		2,
+	expect(open).toHaveBeenCalledWith(
 		"",
-		"tasterr-plex-auth",
-		"popup=yes,width=600,height=700,scrollbars=yes,resizable=yes",
+		"_blank",
+		"width=600,height=700,left=1700,top=250",
 	);
-	expect(approval.opener).toBeNull();
-	expect(replace).toHaveBeenCalledWith("https://app.plex.tv/auth#?x");
-	cleanup();
-	expect(close).toHaveBeenCalledOnce();
 });
 
 test("plex flow can complete after the user closes the approval window", async () => {

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -14,13 +14,24 @@ interface PendingPin {
 	authUrl: string;
 }
 
-const PLEX_POPUP_FEATURES =
-	"popup=yes,width=600,height=700,scrollbars=yes,resizable=yes";
+const PLEX_POPUP_WIDTH = 600;
+const PLEX_POPUP_HEIGHT = 700;
+
+function plexPopupFeatures() {
+	const left = Math.round(
+		window.screenX + (window.outerWidth - PLEX_POPUP_WIDTH) / 2,
+	);
+	const top = Math.round(
+		window.screenY + (window.outerHeight - PLEX_POPUP_HEIGHT) / 2,
+	);
+	return `width=${PLEX_POPUP_WIDTH},height=${PLEX_POPUP_HEIGHT},left=${left},top=${top}`;
+}
 
 export function Login() {
 	const queryClient = useQueryClient();
 	const [pin, setPin] = useState<PendingPin | null>(null);
 	const [plexError, setPlexError] = useState<string | null>(null);
+	const [popupFailed, setPopupFailed] = useState(false);
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
 	const approvalWindow = useRef<Window | null>(null);
@@ -37,23 +48,32 @@ export function Login() {
 	function navigateApprovalWindow(authUrl: string) {
 		const approval = approvalWindow.current;
 		try {
-			if (approval !== null && !approval.closed) {
-				approval.location.replace(authUrl);
+			if (approval === null) return;
+			if (approval.closed) {
+				setPopupFailed(true);
+				return;
 			}
+			approval.location.replace(authUrl);
 		} catch {
 			approvalWindow.current = null;
+			setPopupFailed(true);
 		}
 	}
 
-	function openApprovalWindow(authUrl?: string) {
+	function openApprovalWindow() {
 		closeApprovalWindow();
-		const approval = window.open("", "tasterr-plex-auth", PLEX_POPUP_FEATURES);
-		if (approval === null) return;
+		setPopupFailed(false);
+		const approval = window.open("", "_blank", plexPopupFeatures());
+		if (approval === null) {
+			setPopupFailed(true);
+			return;
+		}
 		approvalWindow.current = approval;
 		try {
 			approval.opener = null;
 		} catch {
 			closeApprovalWindow();
+			setPopupFailed(true);
 			return;
 		}
 		try {
@@ -61,7 +81,6 @@ export function Login() {
 		} catch {
 			// Focus is progressive enhancement; polling remains authoritative.
 		}
-		if (authUrl !== undefined) navigateApprovalWindow(authUrl);
 	}
 
 	const startPlex = useMutation({
@@ -160,14 +179,28 @@ export function Login() {
 						{pin !== null ? "Waiting for Plex approval…" : "Sign in with Plex"}
 					</button>
 					{pin !== null && (
-						<p className="text-sm text-app-subtle">
-							Approve the sign-in in the Plex window, then come back here.{" "}
-							<button
-								type="button"
-								onClick={() => openApprovalWindow(pin.authUrl)}
+						<p
+							role={popupFailed ? "alert" : undefined}
+							className={`text-sm ${popupFailed ? "text-status-error" : "text-app-subtle"}`}
+						>
+							{popupFailed
+								? "We couldn't open the Plex window — "
+								: "Approve the sign-in in the Plex window, then come back here. "}
+							<a
+								href={pin.authUrl}
+								target="_blank"
+								rel="noopener noreferrer"
 								className="underline"
 							>
-								Reopen the approval page
+								{popupFailed ? "open it here" : "Open the approval page"}
+							</a>
+							.{" "}
+							<button
+								type="button"
+								onClick={() => void navigator.clipboard.writeText(pin.authUrl)}
+								className="underline"
+							>
+								Copy approval URL
 							</button>
 						</p>
 					)}

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -27,11 +27,48 @@ function plexPopupFeatures() {
 	return `width=${PLEX_POPUP_WIDTH},height=${PLEX_POPUP_HEIGHT},left=${left},top=${top}`;
 }
 
+async function copyText(value: string): Promise<boolean> {
+	if (navigator.clipboard !== undefined) {
+		try {
+			await navigator.clipboard.writeText(value);
+			return true;
+		} catch {
+			// Fall back for denied clipboard permissions.
+		}
+	}
+
+	const activeElement =
+		document.activeElement instanceof HTMLElement
+			? document.activeElement
+			: null;
+	const textarea = document.createElement("textarea");
+	textarea.value = value;
+	textarea.readOnly = true;
+	textarea.tabIndex = -1;
+	textarea.setAttribute("aria-hidden", "true");
+	textarea.style.position = "fixed";
+	textarea.style.opacity = "0";
+	document.body.append(textarea);
+	try {
+		textarea.focus();
+		textarea.select();
+		return document.execCommand("copy");
+	} catch {
+		return false;
+	} finally {
+		textarea.remove();
+		activeElement?.focus();
+	}
+}
+
 export function Login() {
 	const queryClient = useQueryClient();
 	const [pin, setPin] = useState<PendingPin | null>(null);
 	const [plexError, setPlexError] = useState<string | null>(null);
 	const [popupFailed, setPopupFailed] = useState(false);
+	const [copyStatus, setCopyStatus] = useState<"copied" | "failed" | null>(
+		null,
+	);
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
 	const approvalWindow = useRef<Window | null>(null);
@@ -63,6 +100,7 @@ export function Login() {
 	function openApprovalWindow() {
 		closeApprovalWindow();
 		setPopupFailed(false);
+		setCopyStatus(null);
 		const approval = window.open("", "_blank", plexPopupFeatures());
 		if (approval === null) {
 			setPopupFailed(true);
@@ -83,6 +121,11 @@ export function Login() {
 		}
 	}
 
+	async function copyApprovalUrl(authUrl: string, source: HTMLButtonElement) {
+		const status = (await copyText(authUrl)) ? "copied" : "failed";
+		if (source.isConnected) setCopyStatus(status);
+	}
+
 	const startPlex = useMutation({
 		mutationFn: createPlexPin,
 		onSuccess: (created) => {
@@ -92,6 +135,7 @@ export function Login() {
 		},
 		onError: () => {
 			closeApprovalWindow();
+			setCopyStatus(null);
 			setPlexError("Could not reach Plex — try again.");
 		},
 	});
@@ -129,6 +173,7 @@ export function Login() {
 	useEffect(() => {
 		if (pollError !== null) {
 			closeApprovalWindow();
+			setCopyStatus(null);
 			setPlexError(
 				pollError instanceof ApiError && pollError.status === 404
 					? "Plex sign-in expired — try again."
@@ -166,7 +211,7 @@ export function Login() {
 		>
 			<h1 className="text-4xl font-bold tracking-tight">Tasterr</h1>
 			<div className="flex w-full max-w-sm flex-col gap-6">
-				<div className="flex flex-col gap-2">
+				<div className="flex flex-col gap-2" aria-live="polite">
 					<button
 						type="button"
 						onClick={() => {
@@ -180,12 +225,11 @@ export function Login() {
 					</button>
 					{pin !== null && (
 						<p
-							role={popupFailed ? "alert" : undefined}
 							className={`text-sm ${popupFailed ? "text-status-error" : "text-app-subtle"}`}
 						>
 							{popupFailed
 								? "We couldn't open the Plex window — "
-								: "Approve the sign-in in the Plex window, then come back here. "}
+								: "Approve the sign-in with Plex, then come back here. "}
 							<a
 								href={pin.authUrl}
 								target="_blank"
@@ -197,11 +241,22 @@ export function Login() {
 							.{" "}
 							<button
 								type="button"
-								onClick={() => void navigator.clipboard.writeText(pin.authUrl)}
+								onClick={(event) =>
+									void copyApprovalUrl(pin.authUrl, event.currentTarget)
+								}
 								className="underline"
 							>
 								Copy approval URL
 							</button>
+						</p>
+					)}
+					{copyStatus !== null && (
+						<p
+							className={`text-sm ${copyStatus === "failed" ? "text-status-error" : "text-app-subtle"}`}
+						>
+							{copyStatus === "copied"
+								? "Approval URL copied."
+								: "Could not copy the approval URL. Use the approval link instead."}
 						</p>
 					)}
 					{plexError !== null && (


### PR DESCRIPTION
## What / why

Keep Plex sign-in recoverable when browsers block, close, or sever the approval popup by always presenting a durable approval link. Provide resilient URL copying on secure and plain-HTTP deployments, restore focus after fallback copying, suppress feedback from ended approval flows, and announce success or failure accessibly.

## Spec

- OpenSpec change: `n/a: bug fix`
- [x] Change archived on this branch (not applicable: bug fix)

## Checklist

- [x] `just check` passes locally
- [x] Title is the Conventional Commit subject for the squash
