### PR TITLE
feat: improve tooling, Plex recovery, and discovery rails

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -5,6 +5,11 @@
       "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e",
       "integrity": "sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e"
     },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.1",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:94879eebb6a0e4e2f197de9f12db7427cb4a25b82d93c55239ce8c8fc394a1b4",
+      "integrity": "sha256:94879eebb6a0e4e2f197de9f12db7427cb4a25b82d93c55239ce8c8fc394a1b4"
+    },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "1.7.1",
       "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
 	"build": { "dockerfile": "Dockerfile" },
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": { "version": "24" },
-		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 	// Dependency trees live on container volumes: faster than Windows bind
 	// mounts, and host antivirus never touches (or quarantines) them.
@@ -15,7 +16,7 @@
 		// venv volume and uv cache are different filesystems; copy, don't hardlink
 		"UV_LINK_MODE": "copy"
 	},
-	"postCreateCommand": "sudo chown -R vscode:vscode backend/.venv frontend/node_modules && (cd backend && uv sync) && (cd frontend && npm ci)",
+	"postCreateCommand": "sudo chown -R vscode:vscode backend/.venv frontend/node_modules && (cd backend && uv sync) && (cd frontend && npm ci) && npm install --global @fission-ai/openspec@1",
 	"remoteUser": "vscode",
 	"customizations": {
 		"vscode": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@ in the container, full stop.
 - VS Code: "Reopen in Container". Headless / agents:
   `npx @devcontainers/cli up --workspace-folder .` once, then
   `npx @devcontainers/cli exec --workspace-folder . <command>` for everything else.
+- Run `gh auth login` once per container before creating a PR; re-run it after a
+  rebuild because the container home directory is ephemeral.
 - `docker build` / `docker run` work inside the container via
   docker-outside-of-docker (they drive the host engine).
 

--- a/backend/src/tasterr/catalog/plex.py
+++ b/backend/src/tasterr/catalog/plex.py
@@ -181,7 +181,7 @@ class PlexCatalogService:
             return_exceptions=True,
         )
         resolver = _MetadataResolver(self._plex)
-        pending: list[tuple[int, PlexServer, PlexPmsItem, int, int, str | None]] = []
+        pending: list[tuple[int, PlexServer, PlexPmsItem, int, int | None, str | None]] = []
         for server_index, (server, result) in enumerate(zip(servers, hub_results, strict=True)):
             if isinstance(result, asyncio.CancelledError):
                 raise result
@@ -189,13 +189,26 @@ class PlexCatalogService:
                 continue
             if isinstance(result, BaseException):
                 raise result
-            for item in result:
+            for source_position, item in enumerate(result):
                 if item.media_type not in ("movie", "episode"):
                     continue
                 progress = _progress(item)
-                timestamp = item.last_viewed_at
-                if progress is None or timestamp is None:
+                # Plex omits viewOffset for next-up rows; explicit null or junk is not proof.
+                next_up = (
+                    item.media_type == "episode" and "view_offset" not in item.model_fields_set
+                )
+                if progress is None and not next_up:
                     continue
+                timestamp = (
+                    item.last_viewed_at
+                    or item.grandparent_last_viewed_at
+                    or item.parent_last_viewed_at
+                )
+                if timestamp is None:
+                    if not next_up:
+                        continue
+                    # Negative sentinels preserve the flattened Continue Watching order.
+                    timestamp = -(source_position + 1)
                 context = None
                 if item.media_type == "episode":
                     context = _episode_context(item)
@@ -203,7 +216,7 @@ class PlexCatalogService:
                         continue
                 pending.append((server_index, server, item, timestamp, progress, context))
         pending.sort(key=lambda value: (-value[3], value[0]))
-        selected: list[tuple[int, PlexServer, PlexPmsItem, int, int, str | None]] = []
+        selected: list[tuple[int, PlexServer, PlexPmsItem, int, int | None, str | None]] = []
         seen_raw_keys: set[tuple[int, str, str]] = set()
         for candidate in pending:
             tmdb_id = _tmdb_guid(candidate[2]) if candidate[2].media_type == "movie" else None
@@ -278,8 +291,6 @@ class PlexCatalogService:
         if self._catalog is None:
             raise RuntimeError("TMDB catalog is required for Continue Watching")
         detail = await self._catalog.detail(item.media_type, item.tmdb_id)
-        if item.progress_percent is None:
-            raise ValueError("Continue Watching item omitted progress")
         return MediaSummary(
             id=detail.id,
             media_type=detail.media_type,
@@ -412,8 +423,13 @@ def _merge_candidates(items: list[_Candidate]) -> list[_Candidate]:
     for item in items:
         key = (item.media_type, item.tmdb_id)
         current = merged.get(key)
-        if current is None or (item.timestamp, -item.server_index) > (
+        if current is None or (
+            item.timestamp,
+            item.progress_percent is not None,
+            -item.server_index,
+        ) > (
             current.timestamp,
+            current.progress_percent is not None,
             -current.server_index,
         ):
             merged[key] = item

--- a/backend/src/tasterr/clients/plex.py
+++ b/backend/src/tasterr/clients/plex.py
@@ -92,6 +92,10 @@ class PlexPmsItem(BaseModel):
     account_id: PositiveInt | None = Field(default=None, alias="accountID")
     viewed_at: PositiveInt | None = Field(default=None, alias="viewedAt")
     last_viewed_at: PositiveInt | None = Field(default=None, alias="lastViewedAt")
+    grandparent_last_viewed_at: PositiveInt | None = Field(
+        default=None, alias="grandparentLastViewedAt"
+    )
+    parent_last_viewed_at: PositiveInt | None = Field(default=None, alias="parentLastViewedAt")
     media_type: StrictStr = Field(default="", alias="type")
     rating_key: StrictInt | StrictStr | None = Field(default=None, alias="ratingKey")
     grandparent_rating_key: StrictInt | StrictStr | None = Field(
@@ -102,6 +106,16 @@ class PlexPmsItem(BaseModel):
     view_offset: int | float | None = Field(default=None, alias="viewOffset")
     duration: int | float | None = None
     guids: list[PlexGuid] = Field(default=[], alias="Guid")
+
+    @field_validator(
+        "last_viewed_at",
+        "grandparent_last_viewed_at",
+        "parent_last_viewed_at",
+        mode="before",
+    )
+    @classmethod
+    def validate_optional_timestamp(cls, value: object) -> object:
+        return value if type(value) is int and value > 0 else None
 
     @field_validator("view_offset", "duration", mode="before")
     @classmethod

--- a/backend/src/tasterr/rails/registry.py
+++ b/backend/src/tasterr/rails/registry.py
@@ -8,16 +8,19 @@ toggles. The personalized fetches swallow *any* engine failure to an empty
 rail — personalization degrades, it never blocks browsing.
 """
 
+import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import date, timedelta
+from itertools import zip_longest
 
 from pydantic import SecretStr
 
 from tasterr.catalog.models import MediaSummary, MediaType, RailKind, ServiceOption
 from tasterr.catalog.plex import PlexCatalogService
 from tasterr.catalog.service import CatalogService
+from tasterr.clients.errors import UpstreamError
 from tasterr.db.models import User
 from tasterr.recommend.service import TasteService
 from tasterr.runtime_settings import RailType
@@ -31,6 +34,7 @@ HERO_SIZE = 5
 EXTRA_PAGE_SIZE = 4
 HERO_GENRE_LABELS = 3
 SERVICE_RAIL_LIMIT = 4
+SERVICE_RAIL_SIZE = 20
 
 DECADES = (2020, 2010, 2000, 1990, 1980)
 _GENRE_MIN_VOTES = {"movie": 50, "tv": 30}
@@ -278,15 +282,25 @@ def decade_provider(decade: int) -> RailProvider:
 
 
 def service_provider(service: ServiceOption) -> RailProvider:
+    async def discover(ctx: RailContext, media: MediaType, sort_by: str) -> list[MediaSummary]:
+        try:
+            return await ctx.catalog.discover(
+                media,
+                sort_by=sort_by,
+                release_gte=_days_ago(365),
+                release_lte=_today(),
+                min_votes=3,
+                service_ids=[service.provider_id],
+            )
+        except UpstreamError:
+            return []
+
     async def fetch(ctx: RailContext) -> list[MediaSummary]:
-        return await ctx.catalog.discover(
-            "movie",
-            sort_by="primary_release_date.desc",
-            release_gte=_days_ago(365),
-            release_lte=_today(),
-            min_votes=3,
-            service_ids=[service.provider_id],
+        movies, tv = await asyncio.gather(
+            discover(ctx, "movie", "primary_release_date.desc"),
+            discover(ctx, "tv", "first_air_date.desc"),
         )
+        return _interleave(movies, tv)
 
     return RailProvider(
         f"service-{service.provider_id}",
@@ -294,4 +308,11 @@ def service_provider(service: ServiceOption) -> RailProvider:
         "standard",
         fetch,
         RailType.SERVICES,
+        min_items=SERVICE_RAIL_SIZE // 2,
     )
+
+
+def _interleave(movies: list[MediaSummary], tv: list[MediaSummary]) -> list[MediaSummary]:
+    return [item for pair in zip_longest(movies, tv) for item in pair if item is not None][
+        :SERVICE_RAIL_SIZE
+    ]

--- a/backend/tests/live/test_plex_live.py
+++ b/backend/tests/live/test_plex_live.py
@@ -336,34 +336,32 @@ async def test_history_is_account_filtered_isolated_and_paged() -> None:
 
 
 @requires_roles
-async def test_continue_watching_is_role_scoped_and_has_merge_timestamps() -> None:
+async def test_continue_watching_is_role_scoped_and_has_merge_order() -> None:
     states = await _load_states()
-    fingerprints: list[set[tuple[str, str, int, float, float]]] = []
+    fingerprints: list[set[tuple[str, str]]] = []
+    next_up_sources: set[str] = set()
     for state in states:
         _require(bool(state.continue_watching), f"{state.role} has no seeded Continue Watching")
-        rows: set[tuple[str, str, int, float, float]] = set()
-        timestamps: list[int] = []
+        rows: set[tuple[str, str]] = set()
         for item in state.continue_watching:
-            if (
-                item.last_viewed_at is not None
-                and isinstance(item.view_offset, (int, float))
-                and isinstance(item.duration, (int, float))
-            ):
-                timestamps.append(item.last_viewed_at)
-                rows.add(
-                    (
-                        item.media_type,
-                        str(item.rating_key),
-                        item.last_viewed_at,
-                        float(item.view_offset),
-                        float(item.duration),
-                    )
+            has_progress = isinstance(item.view_offset, (int, float)) and isinstance(
+                item.duration, (int, float)
+            )
+            next_up = item.media_type == "episode" and "view_offset" not in item.model_fields_set
+            if not has_progress and not next_up:
+                continue
+            if next_up:
+                next_up_sources.add(
+                    "lastViewedAt"
+                    if item.last_viewed_at is not None
+                    else "grandparentLastViewedAt"
+                    if item.grandparent_last_viewed_at is not None
+                    else "parentLastViewedAt"
+                    if item.parent_last_viewed_at is not None
+                    else "hub-position fallback"
                 )
-        _require(bool(rows), f"{state.role} Continue Watching lacked progress/timestamps")
-        _require(
-            timestamps == sorted(timestamps, reverse=True),
-            f"{state.role} Continue Watching was not newest-first",
-        )
+            rows.add((item.media_type, str(item.rating_key)))
+        _require(bool(rows), f"{state.role} Continue Watching lacked eligible rows")
         fingerprints.append(rows)
 
     for index, own in enumerate(fingerprints):
@@ -371,6 +369,10 @@ async def test_continue_watching_is_role_scoped_and_has_merge_timestamps() -> No
             item for other, rows in enumerate(fingerprints) if other != index for item in rows
         }
         _require(bool(own - others), "a Plex role lacked an isolated Continue Watching row")
+    print(
+        "Continue Watching next-up ordering sources: "
+        + (", ".join(sorted(next_up_sources)) if next_up_sources else "not exercised")
+    )
 
 
 @requires_roles

--- a/backend/tests/live/test_plex_live.py
+++ b/backend/tests/live/test_plex_live.py
@@ -336,7 +336,7 @@ async def test_history_is_account_filtered_isolated_and_paged() -> None:
 
 
 @requires_roles
-async def test_continue_watching_is_role_scoped_and_has_merge_order() -> None:
+async def test_continue_watching_is_role_scoped_and_reports_next_up_sources() -> None:
     states = await _load_states()
     fingerprints: list[set[tuple[str, str]]] = []
     next_up_sources: set[str] = set()

--- a/backend/tests/test_catalog_plex.py
+++ b/backend/tests/test_catalog_plex.py
@@ -19,6 +19,8 @@ from tasterr.clients.plex import (
     PlexServerDiscovery,
 )
 
+_MISSING = object()
+
 
 def _server(index: int) -> PlexServer:
     return PlexServer(
@@ -36,24 +38,30 @@ def _item(
     grandparent_rating_key: int | None = None,
     viewed_at: int | None = 100,
     last_viewed_at: int | None = None,
-    view_offset: int | float | None = None,
+    grandparent_last_viewed_at: int | None = None,
+    parent_last_viewed_at: int | None = None,
+    view_offset: int | float | None | object = _MISSING,
     duration: int | float | None = None,
     parent_index: int | None = None,
     index: int | None = None,
 ) -> PlexPmsItem:
-    return PlexPmsItem(
-        accountID=1,
-        viewedAt=viewed_at,
-        lastViewedAt=last_viewed_at,
-        type=media_type,
-        ratingKey=rating_key,
-        grandparentRatingKey=grandparent_rating_key,
-        viewOffset=view_offset,
-        duration=duration,
-        parentIndex=parent_index,
-        index=index,
-        Guid=[] if tmdb_id is None else [PlexGuid(id=f"tmdb://{tmdb_id}")],
-    )
+    data: dict[str, object] = {
+        "accountID": 1,
+        "viewedAt": viewed_at,
+        "lastViewedAt": last_viewed_at,
+        "grandparentLastViewedAt": grandparent_last_viewed_at,
+        "parentLastViewedAt": parent_last_viewed_at,
+        "type": media_type,
+        "ratingKey": rating_key,
+        "grandparentRatingKey": grandparent_rating_key,
+        "duration": duration,
+        "parentIndex": parent_index,
+        "index": index,
+        "Guid": [] if tmdb_id is None else [PlexGuid(id=f"tmdb://{tmdb_id}")],
+    }
+    if view_offset is not _MISSING:
+        data["viewOffset"] = view_offset
+    return PlexPmsItem.model_validate(data)
 
 
 class FakePlex:
@@ -347,6 +355,121 @@ async def test_continue_watching_maps_progress_episode_context_and_duplicate_ord
     assert "server-token" not in repr(result)
 
 
+async def test_continue_watching_includes_next_up_by_item_show_and_season_timestamp() -> None:
+    fake = FakePlex()
+    fake.hubs["server-0"] = [
+        _item(
+            media_type="episode",
+            rating_key=20,
+            grandparent_rating_key=21,
+            last_viewed_at=500,
+            grandparent_last_viewed_at=400,
+            parent_last_viewed_at=100,
+            parent_index=1,
+            index=2,
+        ),
+        _item(
+            media_type="episode",
+            rating_key=30,
+            grandparent_rating_key=31,
+            grandparent_last_viewed_at=400,
+            parent_last_viewed_at=600,
+            parent_index=2,
+            index=3,
+        ),
+        _item(
+            media_type="episode",
+            rating_key=40,
+            grandparent_rating_key=41,
+            parent_last_viewed_at=450,
+            parent_index=3,
+            index=4,
+        ),
+    ]
+    fake.metadata_items[("server-0", "21")] = _item(11, rating_key=21)
+    fake.metadata_items[("server-0", "31")] = _item(12, rating_key=31)
+    fake.metadata_items[("server-0", "41")] = _item(13, rating_key=41)
+
+    result = await _service(fake).continue_watching(7, "token")
+
+    assert [(item.id, item.progress_percent, item.context) for item in result] == [
+        (11, None, "S1 E2"),
+        (13, None, "S3 E4"),
+        (12, None, "S2 E3"),
+    ]
+
+
+async def test_continue_watching_preserves_hub_order_without_timestamps() -> None:
+    fake = FakePlex(2)
+    fake.hubs["server-0"] = [
+        _item(
+            media_type="episode",
+            rating_key=20,
+            grandparent_rating_key=21,
+            parent_index=1,
+            index=2,
+        ),
+        _item(
+            media_type="episode",
+            rating_key=30,
+            grandparent_rating_key=31,
+            parent_index=1,
+            index=3,
+        ),
+    ]
+    fake.hubs["server-1"] = [
+        _item(
+            media_type="episode",
+            rating_key=40,
+            grandparent_rating_key=41,
+            parent_index=1,
+            index=4,
+        )
+    ]
+    fake.metadata_items[("server-0", "21")] = _item(11, rating_key=21)
+    fake.metadata_items[("server-0", "31")] = _item(12, rating_key=31)
+    fake.metadata_items[("server-1", "41")] = _item(13, rating_key=41)
+
+    result = await _service(fake).continue_watching(7, "token")
+
+    assert [(item.id, item.progress_percent) for item in result] == [
+        (11, None),
+        (13, None),
+        (12, None),
+    ]
+
+
+async def test_continue_watching_prefers_progress_on_equal_show_timestamp() -> None:
+    fake = FakePlex()
+    fake.hubs["server-0"] = [
+        _item(
+            media_type="episode",
+            rating_key=20,
+            grandparent_rating_key=21,
+            grandparent_last_viewed_at=200,
+            parent_index=1,
+            index=2,
+        ),
+        _item(
+            media_type="episode",
+            rating_key=30,
+            grandparent_rating_key=21,
+            last_viewed_at=200,
+            view_offset=50,
+            duration=100,
+            parent_index=1,
+            index=1,
+        ),
+    ]
+    fake.metadata_items[("server-0", "21")] = _item(11, rating_key=21)
+
+    result = await _service(fake).continue_watching(7, "token")
+
+    assert [(item.id, item.progress_percent, item.context) for item in result] == [
+        (11, 50, "S1 E1")
+    ]
+
+
 async def test_continue_watching_skips_invalid_progress_context_and_partial_server() -> None:
     fake = FakePlex(2)
     fake.hubs["server-0"] = [
@@ -355,6 +478,7 @@ async def test_continue_watching_skips_invalid_progress_context_and_partial_serv
         _item(3, last_viewed_at=3, view_offset=1, duration=0),
         _item(7, last_viewed_at=7, view_offset=True, duration=100),
         _item(8, last_viewed_at=8, view_offset=1, duration=True),
+        _item(9, last_viewed_at=9, duration=100),
         _item(
             media_type="episode",
             rating_key=4,
@@ -364,6 +488,26 @@ async def test_continue_watching_skips_invalid_progress_context_and_partial_serv
             duration=100,
             parent_index=0,
             index=1,
+        ),
+        _item(
+            media_type="episode",
+            rating_key=10,
+            grandparent_rating_key=100,
+            last_viewed_at=10,
+            view_offset=True,
+            duration=100,
+            parent_index=1,
+            index=1,
+        ),
+        _item(
+            media_type="episode",
+            rating_key=11,
+            grandparent_rating_key=110,
+            last_viewed_at=11,
+            view_offset=None,
+            duration=100,
+            parent_index=1,
+            index=2,
         ),
         _item(5, last_viewed_at=5, view_offset=99, duration=100),
         _item(6, last_viewed_at=6, view_offset=1, duration=100),

--- a/backend/tests/test_catalog_plex.py
+++ b/backend/tests/test_catalog_plex.py
@@ -440,7 +440,7 @@ async def test_continue_watching_preserves_hub_order_without_timestamps() -> Non
 
 
 async def test_continue_watching_prefers_progress_on_equal_show_timestamp() -> None:
-    fake = FakePlex()
+    fake = FakePlex(2)
     fake.hubs["server-0"] = [
         _item(
             media_type="episode",
@@ -450,6 +450,8 @@ async def test_continue_watching_prefers_progress_on_equal_show_timestamp() -> N
             parent_index=1,
             index=2,
         ),
+    ]
+    fake.hubs["server-1"] = [
         _item(
             media_type="episode",
             rating_key=30,
@@ -462,6 +464,7 @@ async def test_continue_watching_prefers_progress_on_equal_show_timestamp() -> N
         ),
     ]
     fake.metadata_items[("server-0", "21")] = _item(11, rating_key=21)
+    fake.metadata_items[("server-1", "21")] = _item(11, rating_key=21)
 
     result = await _service(fake).continue_watching(7, "token")
 

--- a/backend/tests/test_clients_plex.py
+++ b/backend/tests/test_clients_plex.py
@@ -796,12 +796,14 @@ async def test_continue_watching_reads_nested_hub_and_caps_at_fifty() -> None:
     assert items[0].index == 4
 
 
-async def test_continue_watching_drops_coercive_progress_and_episode_coordinates() -> None:
+async def test_continue_watching_drops_coercive_optional_values() -> None:
     row = {
         "type": "episode",
         "ratingKey": True,
         "grandparentRatingKey": 1.0,
-        "lastViewedAt": 100,
+        "lastViewedAt": "100",
+        "grandparentLastViewedAt": 0,
+        "parentLastViewedAt": 1.5,
         "viewOffset": "5",
         "duration": True,
         "parentIndex": "2",
@@ -818,6 +820,9 @@ async def test_continue_watching_drops_coercive_progress_and_episode_coordinates
 
     assert item.rating_key is None
     assert item.grandparent_rating_key is None
+    assert item.last_viewed_at is None
+    assert item.grandparent_last_viewed_at is None
+    assert item.parent_last_viewed_at is None
     assert item.view_offset is None
     assert item.duration is None
     assert item.parent_index is None

--- a/backend/tests/test_clients_plex.py
+++ b/backend/tests/test_clients_plex.py
@@ -809,14 +809,21 @@ async def test_continue_watching_drops_coercive_optional_values() -> None:
         "parentIndex": "2",
         "index": True,
     }
+    bool_timestamps = {
+        "type": "episode",
+        "ratingKey": "2",
+        "lastViewedAt": True,
+        "grandparentLastViewedAt": True,
+        "parentLastViewedAt": True,
+    }
 
     def handler(_: httpx.Request) -> httpx.Response:
         return httpx.Response(
             200,
-            json={"MediaContainer": {"Hub": [{"Metadata": [row]}]}},
+            json={"MediaContainer": {"Hub": [{"Metadata": [row, bool_timestamps]}]}},
         )
 
-    item = (await _media_client(handler).continue_watching(_server()))[0]
+    item, bool_item = await _media_client(handler).continue_watching(_server())
 
     assert item.rating_key is None
     assert item.grandparent_rating_key is None
@@ -827,6 +834,9 @@ async def test_continue_watching_drops_coercive_optional_values() -> None:
     assert item.duration is None
     assert item.parent_index is None
     assert item.index is None
+    assert bool_item.last_viewed_at is None
+    assert bool_item.grandparent_last_viewed_at is None
+    assert bool_item.parent_last_viewed_at is None
 
 
 async def test_metadata_requests_guid_expansion_for_movie_and_episode() -> None:

--- a/backend/tests/test_rails.py
+++ b/backend/tests/test_rails.py
@@ -11,6 +11,7 @@ from tasterr.catalog.models import (
     Genre,
     MediaDetail,
     MediaSummary,
+    MediaType,
     Rail,
     ServiceOption,
     WatchProviders,
@@ -22,6 +23,7 @@ from tasterr.rails.composer import build_extra_rails, build_home
 from tasterr.rails.registry import (
     EXTRA_PAGE_SIZE,
     HERO_SIZE,
+    SERVICE_RAIL_SIZE,
     RailContext,
     continue_watching_provider,
     decade_provider,
@@ -33,10 +35,10 @@ from tasterr.rails.registry import (
 from tasterr.runtime_settings import RailType
 
 
-def _summary(i: int) -> MediaSummary:
+def _summary(i: int, media_type: MediaType = "movie") -> MediaSummary:
     return MediaSummary(
         id=i,
-        media_type="movie",
+        media_type=media_type,
         title=f"T{i}",
         overview="",
         poster_path=None,
@@ -81,7 +83,7 @@ class FakeCatalog:
         self.available_services: list[ServiceOption] = []
         self.trending_items = [_summary(i) for i in range(1, 7)]
         self.fixed_discover: list[MediaSummary] | None = None
-        self.service_results: dict[int, list[MediaSummary]] = {}
+        self.service_results: dict[tuple[int, MediaType], list[MediaSummary]] = {}
         self.genre_map_result = {"Action": 28, "Comedy": 35, "Drama": 18, "Thriller": 53}
         self.discover_calls: list[dict[str, object]] = []
         self.fail_trending = False
@@ -89,6 +91,7 @@ class FakeCatalog:
         self.fail_genre_map = False
         self.fail_services = False
         self.failing_service_ids: set[int] = set()
+        self.failing_service_media: set[tuple[int, MediaType]] = set()
         self.genre_map_calls: list[str] = []
         self._block = 100
 
@@ -99,7 +102,7 @@ class FakeCatalog:
 
     async def discover(
         self,
-        media: str,
+        media: MediaType,
         *,
         page: int = 1,
         sort_by: str = "popularity.desc",
@@ -120,17 +123,21 @@ class FakeCatalog:
                 "service_ids": service_ids,
             }
         )
-        if self.fail_discover or (
-            service_ids is not None and bool(self.failing_service_ids.intersection(service_ids))
+        if (
+            self.fail_discover
+            or (
+                service_ids is not None and bool(self.failing_service_ids.intersection(service_ids))
+            )
+            or (service_ids is not None and (service_ids[0], media) in self.failing_service_media)
         ):
             raise UpstreamUnavailable("discover down")
         if self.fixed_discover is not None:
             return list(self.fixed_discover)
-        if service_ids and service_ids[0] in self.service_results:
-            return list(self.service_results[service_ids[0]])
+        if service_ids and (service_ids[0], media) in self.service_results:
+            return list(self.service_results[(service_ids[0], media)])
         block = self._block
         self._block += 100
-        return [_summary(block + i) for i in range(10)]
+        return [_summary(block + i, media) for i in range(10)]
 
     async def genre_map(self, media: str) -> dict[str, int]:
         self.genre_map_calls.append(media)
@@ -352,7 +359,7 @@ def test_top_rated_provider_ids() -> None:
     assert providers[1].title == "Top Rated TV"
 
 
-async def test_service_provider_queries_recent_flatrate_movies() -> None:
+async def test_service_provider_queries_recent_flatrate_movies_and_tv() -> None:
     service = ServiceOption(
         provider_id=8,
         name="Netflix",
@@ -362,18 +369,75 @@ async def test_service_provider_queries_recent_flatrate_movies() -> None:
     provider = service_provider(service)
     fake = FakeCatalog()
 
-    await provider.fetch(_ctx(fake))
+    items = await provider.fetch(_ctx(fake))
 
     assert provider.title == "Recent Releases on Netflix"
-    assert fake.discover_calls[-1] == {
-        "media": "movie",
-        "sort_by": "primary_release_date.desc",
+    assert provider.min_items == 10
+    assert [item.media_type for item in items] == ["movie", "tv"] * 10
+    common = {
         "genres": None,
         "min_votes": 3,
         "release_gte": (date.today() - timedelta(days=365)).isoformat(),
         "release_lte": date.today().isoformat(),
         "service_ids": [8],
     }
+    calls = {cast("str", call["media"]): call for call in fake.discover_calls}
+    assert calls == {
+        "movie": {
+            "media": "movie",
+            "sort_by": "primary_release_date.desc",
+            **common,
+        },
+        "tv": {
+            "media": "tv",
+            "sort_by": "first_air_date.desc",
+            **common,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("movies", "tv", "expected"),
+    [
+        ([1, 2], [101, 102], [1, 101, 2, 102]),
+        ([1, 2, 3], [101], [1, 101, 2, 3]),
+        ([1], [101, 102, 103], [1, 101, 102, 103]),
+    ],
+)
+async def test_service_interleave_balances_then_fills(
+    movies: list[int], tv: list[int], expected: list[int]
+) -> None:
+    service = ServiceOption(provider_id=8, name="Netflix", logo_path=None, display_priority=1)
+    fake = FakeCatalog()
+    fake.service_results[(8, "movie")] = [_summary(item) for item in movies]
+    fake.service_results[(8, "tv")] = [_summary(item, "tv") for item in tv]
+
+    result = await service_provider(service).fetch(_ctx(fake))
+
+    assert [item.id for item in result] == expected
+
+
+async def test_service_interleave_is_capped() -> None:
+    service = ServiceOption(provider_id=8, name="Netflix", logo_path=None, display_priority=1)
+    fake = FakeCatalog()
+    fake.service_results[(8, "movie")] = [_summary(item) for item in range(15)]
+    fake.service_results[(8, "tv")] = [_summary(100 + item, "tv") for item in range(15)]
+
+    result = await service_provider(service).fetch(_ctx(fake))
+
+    assert len(result) == SERVICE_RAIL_SIZE
+    assert [item.media_type for item in result] == ["movie", "tv"] * 10
+
+
+async def test_service_provider_keeps_one_healthy_media_type() -> None:
+    service = ServiceOption(provider_id=8, name="Netflix", logo_path=None, display_priority=1)
+    fake = FakeCatalog()
+    fake.failing_service_media = {(8, "tv")}
+
+    items = await service_provider(service).fetch(_ctx(fake))
+
+    assert len(items) == 10
+    assert {item.media_type for item in items} == {"movie"}
 
 
 async def test_disabled_provider_is_not_fetched() -> None:
@@ -425,7 +489,46 @@ async def test_selected_services_add_four_ordered_independent_rails() -> None:
         "service-15",
     ]
     service_calls = [call for call in fake.discover_calls if call["service_ids"] is not None]
-    assert [call["service_ids"] for call in service_calls] == [[8], [337], [9], [15]]
+    queries = {
+        (
+            cast("list[int]", call["service_ids"])[0],
+            cast("str", call["media"]),
+        )
+        for call in service_calls
+    }
+    assert queries == {
+        (8, "movie"),
+        (8, "tv"),
+        (9, "movie"),
+        (9, "tv"),
+        (15, "movie"),
+        (15, "tv"),
+        (337, "movie"),
+        (337, "tv"),
+    }
+
+
+async def test_underfilled_service_rail_is_omitted_after_deduplication() -> None:
+    fake = FakeCatalog()
+    fake.selected_service_ids = (8, 9)
+    fake.available_services = [
+        ServiceOption(provider_id=8, name="Netflix", logo_path=None, display_priority=1),
+        ServiceOption(provider_id=9, name="Prime", logo_path=None, display_priority=2),
+    ]
+    fake.service_results[(8, "movie")] = [
+        *(_summary(item) for item in range(5)),
+        _summary(0),
+    ]
+    fake.service_results[(8, "tv")] = [_summary(100 + item, "tv") for item in range(4)]
+    fake.service_results[(9, "movie")] = [_summary(200 + item) for item in range(5)]
+    fake.service_results[(9, "tv")] = [_summary(300 + item, "tv") for item in range(5)]
+
+    rails = await _all_extra_rails(_ctx(fake))
+
+    ids = {rail.id for rail in rails}
+    assert "service-8" not in ids
+    assert "service-9" in ids
+    assert "top-rated-movie" in ids
 
 
 async def test_service_metadata_failure_omits_only_service_rails() -> None:
@@ -545,11 +648,10 @@ async def test_cursor_grouping_does_not_underfill_an_overlapping_service_rail() 
         )
         for index, provider_id in enumerate(service_ids)
     ]
-    fake.service_results[9] = [_summary(tmdb_id) for tmdb_id in range(1, 21)]
-    fake.service_results[15] = [
-        *[_summary(tmdb_id) for tmdb_id in range(1, 17)],
-        *[_summary(tmdb_id) for tmdb_id in range(21, 25)],
-    ]
+    fake.service_results[(9, "movie")] = [_summary(tmdb_id) for tmdb_id in range(1, 11)]
+    fake.service_results[(9, "tv")] = [_summary(tmdb_id, "tv") for tmdb_id in range(11, 21)]
+    fake.service_results[(15, "movie")] = [_summary(tmdb_id) for tmdb_id in range(1, 11)]
+    fake.service_results[(15, "tv")] = [_summary(tmdb_id, "tv") for tmdb_id in range(21, 31)]
 
     page = await build_extra_rails(_ctx(fake), 4)
     by_id = {rail.id: rail for rail in page.rails}

--- a/frontend/src/components/MediaCard.test.tsx
+++ b/frontend/src/components/MediaCard.test.tsx
@@ -29,6 +29,17 @@ test("ordinary cards have no progress UI", () => {
 	expect(screen.queryByRole("progressbar")).toBeNull();
 });
 
+test("next-up cards show episode context without a progress bar", () => {
+	render(
+		<MemoryRouter>
+			<MediaCard item={item(undefined, "S2 E3")} />
+		</MemoryRouter>,
+	);
+
+	expect(screen.getByText("S2 E3")).toBeTruthy();
+	expect(screen.queryByRole("progressbar")).toBeNull();
+});
+
 test("resume cards expose progress and local episode context accessibly", () => {
 	render(
 		<MemoryRouter>

--- a/frontend/src/components/MediaCard.tsx
+++ b/frontend/src/components/MediaCard.tsx
@@ -53,26 +53,28 @@ export function MediaCard({
 						{item.title}
 					</div>
 				)}
-				{progressLabel && (
+				{(progressLabel || item.context) && (
 					<div className="absolute inset-x-0 bottom-0 z-10 bg-black/75 px-1.5 pb-1 pt-1 text-white">
 						<p className="mb-0.5 flex justify-between text-[0.65rem] leading-none">
-							<span>{item.progress_percent}% watched</span>
-							{item.context && <span>{item.context}</span>}
+							{progressLabel && <span>{item.progress_percent}% watched</span>}
+							{item.context && <span className="ml-auto">{item.context}</span>}
 						</p>
-						<div
-							role="progressbar"
-							aria-label={progressLabel}
-							aria-valuemin={0}
-							aria-valuemax={100}
-							aria-valuenow={item.progress_percent ?? undefined}
-							className="h-1 overflow-hidden rounded-full bg-white/40"
-						>
+						{progressLabel && (
 							<div
-								aria-hidden="true"
-								className="h-full bg-app-accent"
-								style={{ width: `${item.progress_percent}%` }}
-							/>
-						</div>
+								role="progressbar"
+								aria-label={progressLabel}
+								aria-valuemin={0}
+								aria-valuemax={100}
+								aria-valuenow={item.progress_percent ?? undefined}
+								className="h-1 overflow-hidden rounded-full bg-white/40"
+							>
+								<div
+									aria-hidden="true"
+									className="h-full bg-app-accent"
+									style={{ width: `${item.progress_percent}%` }}
+								/>
+							</div>
+						)}
 					</div>
 				)}
 			</div>

--- a/frontend/src/routes/Login.test.tsx
+++ b/frontend/src/routes/Login.test.tsx
@@ -110,9 +110,11 @@ test("plex flow protects and closes its approval window after polling succeeds",
 	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
 
 	await screen.findByText("Waiting for Plex approval…");
-	expect(
-		screen.getByRole("link", { name: "Open the approval page" }),
-	).toBeTruthy();
+	const approvalLink = screen.getByRole("link", {
+		name: "Open the approval page",
+	}) as HTMLAnchorElement;
+	expect(approvalLink.target).toBe("_blank");
+	expect(approvalLink.rel).toBe("noopener noreferrer");
 	expect(open).toHaveBeenCalledWith(
 		"",
 		"_blank",
@@ -285,7 +287,10 @@ test("plex flow shows a reachable approval link after popup blocking", async () 
 	const execCommand = vi.fn(() => {
 		const textarea = document.activeElement as HTMLTextAreaElement;
 		expect(textarea.value).toBe("https://app.plex.tv/auth#?x");
+		expect(textarea.readOnly).toBe(true);
+		expect(textarea.tabIndex).toBe(-1);
 		expect(textarea.getAttribute("aria-hidden")).toBe("true");
+		expect(textarea.style.position).toBe("fixed");
 		expect(textarea.style.top).toBe("0px");
 		expect(textarea.style.left).toBe("0px");
 		return true;
@@ -311,11 +316,13 @@ test("plex flow shows a reachable approval link after popup blocking", async () 
 	const copyButton = screen.getByRole("button", {
 		name: "Copy approval URL",
 	});
-	copyButton.focus();
+	const email = screen.getByLabelText("Email");
+	email.focus();
 	fireEvent.click(copyButton);
 	expect(await screen.findByText("Approval URL copied.")).toBeTruthy();
 	expect(execCommand).toHaveBeenCalledWith("copy");
-	expect(document.activeElement).toBe(copyButton);
+	expect(document.activeElement).toBe(email);
+	expect(document.querySelector('textarea[aria-hidden="true"]')).toBeNull();
 });
 
 test("plex flow re-announces repeated copy results", async () => {
@@ -439,14 +446,22 @@ test("plex flow reports when both clipboard paths fail", async () => {
 	renderLogin();
 
 	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
-	await screen.findByRole("button", { name: "Copy approval URL" });
-	fireEvent.click(screen.getByRole("button", { name: "Copy approval URL" }));
+	const copyButton = await screen.findByRole("button", {
+		name: "Copy approval URL",
+	});
+	const email = screen.getByLabelText("Email");
+	email.focus();
+	const restoreFocus = vi.spyOn(email, "focus").mockImplementation(() => {
+		throw new Error("focus blocked");
+	});
+	fireEvent.click(copyButton);
 
 	expect(
 		await screen.findByText(
 			"Could not copy the approval URL. Use the approval link instead.",
 		),
 	).toBeTruthy();
+	expect(restoreFocus).toHaveBeenCalledOnce();
 });
 
 test("plex flow centers the approval window in the current browser window", async () => {

--- a/frontend/src/routes/Login.test.tsx
+++ b/frontend/src/routes/Login.test.tsx
@@ -1,5 +1,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+	act,
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+} from "@testing-library/react";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { ME_QUERY_KEY } from "../lib/auth";
 import { Login } from "./Login";
@@ -12,6 +18,7 @@ afterEach(() => {
 	cleanup();
 	vi.restoreAllMocks();
 	vi.unstubAllGlobals();
+	Reflect.deleteProperty(document, "execCommand");
 });
 
 type Route = (init?: RequestInit) => { status: number; body: unknown };
@@ -91,6 +98,8 @@ test("plex flow protects and closes its approval window after polling succeeds",
 	const { approval, close, focus, replace } = fakeApprovalWindow();
 	const open = vi.fn(() => approval);
 	vi.stubGlobal("open", open);
+	const writeText = vi.fn(() => Promise.resolve());
+	vi.stubGlobal("navigator", { clipboard: { writeText } });
 	const parentFocus = vi.mocked(window.focus);
 	const queryClient = new QueryClient({
 		defaultOptions: { queries: { retry: false } },
@@ -101,14 +110,20 @@ test("plex flow protects and closes its approval window after polling succeeds",
 	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
 
 	await screen.findByText("Waiting for Plex approval…");
+	expect(
+		screen.getByRole("link", { name: "Open the approval page" }),
+	).toBeTruthy();
 	expect(open).toHaveBeenCalledWith(
 		"",
-		"tasterr-plex-auth",
-		"popup=yes,width=600,height=700,scrollbars=yes,resizable=yes",
+		"_blank",
+		expect.stringMatching(/^width=600,height=700,left=-?\d+,top=-?\d+$/),
 	);
 	expect(approval.opener).toBeNull();
 	expect(focus).toHaveBeenCalledOnce();
 	expect(replace).toHaveBeenCalledWith("https://app.plex.tv/auth#?x");
+	fireEvent.click(screen.getByRole("button", { name: "Copy approval URL" }));
+	expect(await screen.findByText("Approval URL copied.")).toBeTruthy();
+	expect(writeText).toHaveBeenCalledWith("https://app.plex.tv/auth#?x");
 	// First poll answers pending; the 2s refetch interval must fire again.
 	await vi.waitFor(() => expect(polls).toBeGreaterThanOrEqual(2), {
 		timeout: 5000,
@@ -248,7 +263,7 @@ test("plex flow can complete when the approval window is blocked", async () => {
 	);
 });
 
-test("plex flow reopens a protected approval window after popup blocking", async () => {
+test("plex flow shows a reachable approval link after popup blocking", async () => {
 	stubFetch({
 		"POST /api/v1/auth/plex/pin": () => ({
 			status: 200,
@@ -262,29 +277,201 @@ test("plex flow reopens a protected approval window after popup blocking", async
 			body: { status: "pending", user: null },
 		}),
 	});
-	const { approval, close, replace } = fakeApprovalWindow();
-	const open = vi
-		.fn<() => Window | null>()
-		.mockReturnValueOnce(null)
-		.mockReturnValueOnce(approval);
+	vi.stubGlobal(
+		"open",
+		vi.fn(() => null),
+	);
+	vi.stubGlobal("navigator", {});
+	const execCommand = vi.fn(() => {
+		const textarea = document.activeElement as HTMLTextAreaElement;
+		expect(textarea.value).toBe("https://app.plex.tv/auth#?x");
+		expect(textarea.getAttribute("aria-hidden")).toBe("true");
+		expect(textarea.style.top).toBe("0px");
+		expect(textarea.style.left).toBe("0px");
+		return true;
+	});
+	Object.defineProperty(document, "execCommand", {
+		configurable: true,
+		value: execCommand,
+	});
+	renderLogin();
+
+	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
+
+	const link = await screen.findByRole("link", { name: "open it here" });
+	expect((link as HTMLAnchorElement).href).toBe("https://app.plex.tv/auth#?x");
+	expect((link as HTMLAnchorElement).target).toBe("_blank");
+	expect((link as HTMLAnchorElement).rel).toBe("noopener noreferrer");
+	expect(
+		screen
+			.getByText(/The Plex window isn't available/)
+			.closest("[aria-live]")
+			?.getAttribute("aria-live"),
+	).toBe("polite");
+	const copyButton = screen.getByRole("button", {
+		name: "Copy approval URL",
+	});
+	copyButton.focus();
+	fireEvent.click(copyButton);
+	expect(await screen.findByText("Approval URL copied.")).toBeTruthy();
+	expect(execCommand).toHaveBeenCalledWith("copy");
+	expect(document.activeElement).toBe(copyButton);
+});
+
+test("plex flow re-announces repeated copy results", async () => {
+	stubFetch({
+		"POST /api/v1/auth/plex/pin": () => ({
+			status: 200,
+			body: {
+				pin_id: "opaque-handle",
+				auth_url: "https://app.plex.tv/auth#?x",
+			},
+		}),
+		"POST /api/v1/auth/plex/pin/poll": () => ({
+			status: 200,
+			body: { status: "pending", user: null },
+		}),
+	});
+	vi.stubGlobal("navigator", {
+		clipboard: { writeText: vi.fn(() => Promise.resolve()) },
+	});
+	const { approval } = fakeApprovalWindow();
+	vi.stubGlobal(
+		"open",
+		vi.fn(() => approval),
+	);
+	renderLogin();
+
+	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
+	const copyButton = await screen.findByRole("button", {
+		name: "Copy approval URL",
+	});
+	fireEvent.click(copyButton);
+	const firstAnnouncement = await screen.findByText("Approval URL copied.");
+	fireEvent.click(copyButton);
+	await vi.waitFor(() =>
+		expect(screen.getByText("Approval URL copied.")).not.toBe(
+			firstAnnouncement,
+		),
+	);
+});
+
+test("plex flow ignores copy feedback after the PIN expires", async () => {
+	let polls = 0;
+	let resolveCopy: () => void = () => undefined;
+	stubFetch({
+		"POST /api/v1/auth/plex/pin": () => ({
+			status: 200,
+			body: {
+				pin_id: "opaque-handle",
+				auth_url: "https://app.plex.tv/auth#?x",
+			},
+		}),
+		"POST /api/v1/auth/plex/pin/poll": () => {
+			polls += 1;
+			return polls === 1
+				? { status: 200, body: { status: "pending", user: null } }
+				: { status: 404, body: { detail: "expired" } };
+		},
+	});
+	vi.stubGlobal("navigator", {
+		clipboard: {
+			writeText: vi.fn(
+				() =>
+					new Promise<void>((resolve) => {
+						resolveCopy = () => resolve();
+					}),
+			),
+		},
+	});
+	const { approval } = fakeApprovalWindow();
+	vi.stubGlobal(
+		"open",
+		vi.fn(() => approval),
+	);
+	renderLogin();
+
+	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
+	const copyButton = await screen.findByRole("button", {
+		name: "Copy approval URL",
+	});
+	fireEvent.click(copyButton);
+	expect(
+		await screen.findByText("Plex sign-in expired — try again.", undefined, {
+			timeout: 5000,
+		}),
+	).toBeTruthy();
+	await act(async () => resolveCopy());
+
+	expect(screen.queryByText("Approval URL copied.")).toBeNull();
+	expect(
+		screen.queryByText(
+			"Could not copy the approval URL. Use the approval link instead.",
+		),
+	).toBeNull();
+}, 10000);
+
+test("plex flow reports when both clipboard paths fail", async () => {
+	stubFetch({
+		"POST /api/v1/auth/plex/pin": () => ({
+			status: 200,
+			body: {
+				pin_id: "opaque-handle",
+				auth_url: "https://app.plex.tv/auth#?x",
+			},
+		}),
+		"POST /api/v1/auth/plex/pin/poll": () => ({
+			status: 200,
+			body: { status: "pending", user: null },
+		}),
+	});
+	vi.stubGlobal("navigator", {
+		clipboard: { writeText: vi.fn(() => Promise.reject(new Error("denied"))) },
+	});
+	Object.defineProperty(document, "execCommand", {
+		configurable: true,
+		value: vi.fn(() => false),
+	});
+	vi.stubGlobal(
+		"open",
+		vi.fn(() => null),
+	);
+	renderLogin();
+
+	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
+	await screen.findByRole("button", { name: "Copy approval URL" });
+	fireEvent.click(screen.getByRole("button", { name: "Copy approval URL" }));
+
+	expect(
+		await screen.findByText(
+			"Could not copy the approval URL. Use the approval link instead.",
+		),
+	).toBeTruthy();
+});
+
+test("plex flow centers the approval window in the current browser window", async () => {
+	stubFetch({
+		"POST /api/v1/auth/plex/pin": () => ({ status: 503, body: {} }),
+	});
+	vi.spyOn(window, "screenX", "get").mockReturnValue(1400);
+	vi.spyOn(window, "screenY", "get").mockReturnValue(100);
+	vi.spyOn(window, "outerWidth", "get").mockReturnValue(1200);
+	vi.spyOn(window, "outerHeight", "get").mockReturnValue(1000);
+	const { approval } = fakeApprovalWindow();
+	const open = vi.fn(() => approval);
 	vi.stubGlobal("open", open);
 	renderLogin();
 
 	fireEvent.click(screen.getByRole("button", { name: "Sign in with Plex" }));
-	fireEvent.click(
-		await screen.findByRole("button", { name: "Reopen the approval page" }),
-	);
 
-	expect(open).toHaveBeenNthCalledWith(
-		2,
+	expect(open).toHaveBeenCalledWith(
 		"",
-		"tasterr-plex-auth",
-		"popup=yes,width=600,height=700,scrollbars=yes,resizable=yes",
+		"_blank",
+		"width=600,height=700,left=1700,top=250",
 	);
-	expect(approval.opener).toBeNull();
-	expect(replace).toHaveBeenCalledWith("https://app.plex.tv/auth#?x");
-	cleanup();
-	expect(close).toHaveBeenCalledOnce();
+	expect(
+		await screen.findByText("Could not reach Plex — try again."),
+	).toBeTruthy();
 });
 
 test("plex flow can complete after the user closes the approval window", async () => {

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -14,16 +14,68 @@ interface PendingPin {
 	authUrl: string;
 }
 
-const PLEX_POPUP_FEATURES =
-	"popup=yes,width=600,height=700,scrollbars=yes,resizable=yes";
+const PLEX_POPUP_WIDTH = 600;
+const PLEX_POPUP_HEIGHT = 700;
+
+function plexPopupFeatures() {
+	const left = Math.round(
+		window.screenX + (window.outerWidth - PLEX_POPUP_WIDTH) / 2,
+	);
+	const top = Math.round(
+		window.screenY + (window.outerHeight - PLEX_POPUP_HEIGHT) / 2,
+	);
+	return `width=${PLEX_POPUP_WIDTH},height=${PLEX_POPUP_HEIGHT},left=${left},top=${top}`;
+}
+
+async function copyText(value: string): Promise<boolean> {
+	if (navigator.clipboard !== undefined) {
+		try {
+			await navigator.clipboard.writeText(value);
+			return true;
+		} catch {
+			// Fall back for denied clipboard permissions.
+		}
+	}
+
+	const activeElement =
+		document.activeElement instanceof HTMLElement
+			? document.activeElement
+			: null;
+	const textarea = document.createElement("textarea");
+	textarea.value = value;
+	textarea.readOnly = true;
+	textarea.tabIndex = -1;
+	textarea.setAttribute("aria-hidden", "true");
+	textarea.style.position = "fixed";
+	textarea.style.top = "0";
+	textarea.style.left = "0";
+	textarea.style.opacity = "0";
+	document.body.append(textarea);
+	try {
+		textarea.focus();
+		textarea.select();
+		return document.execCommand("copy");
+	} catch {
+		return false;
+	} finally {
+		textarea.remove();
+		activeElement?.focus();
+	}
+}
 
 export function Login() {
 	const queryClient = useQueryClient();
 	const [pin, setPin] = useState<PendingPin | null>(null);
 	const [plexError, setPlexError] = useState<string | null>(null);
+	const [popupFailed, setPopupFailed] = useState(false);
+	const [copyStatus, setCopyStatus] = useState<{
+		result: "copied" | "failed";
+		attempt: number;
+	} | null>(null);
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
 	const approvalWindow = useRef<Window | null>(null);
+	const copyAttempt = useRef(0);
 	const closeApprovalWindow = useCallback(() => {
 		const approval = approvalWindow.current;
 		approvalWindow.current = null;
@@ -37,23 +89,33 @@ export function Login() {
 	function navigateApprovalWindow(authUrl: string) {
 		const approval = approvalWindow.current;
 		try {
-			if (approval !== null && !approval.closed) {
-				approval.location.replace(authUrl);
+			if (approval === null) return;
+			if (approval.closed) {
+				setPopupFailed(true);
+				return;
 			}
+			approval.location.replace(authUrl);
 		} catch {
 			approvalWindow.current = null;
+			setPopupFailed(true);
 		}
 	}
 
-	function openApprovalWindow(authUrl?: string) {
+	function openApprovalWindow() {
 		closeApprovalWindow();
-		const approval = window.open("", "tasterr-plex-auth", PLEX_POPUP_FEATURES);
-		if (approval === null) return;
+		setPopupFailed(false);
+		setCopyStatus(null);
+		const approval = window.open("", "_blank", plexPopupFeatures());
+		if (approval === null) {
+			setPopupFailed(true);
+			return;
+		}
 		approvalWindow.current = approval;
 		try {
 			approval.opener = null;
 		} catch {
 			closeApprovalWindow();
+			setPopupFailed(true);
 			return;
 		}
 		try {
@@ -61,7 +123,14 @@ export function Login() {
 		} catch {
 			// Focus is progressive enhancement; polling remains authoritative.
 		}
-		if (authUrl !== undefined) navigateApprovalWindow(authUrl);
+	}
+
+	async function copyApprovalUrl(authUrl: string, source: HTMLButtonElement) {
+		const result = (await copyText(authUrl)) ? "copied" : "failed";
+		if (source.isConnected) {
+			copyAttempt.current += 1;
+			setCopyStatus({ result, attempt: copyAttempt.current });
+		}
 	}
 
 	const startPlex = useMutation({
@@ -73,6 +142,7 @@ export function Login() {
 		},
 		onError: () => {
 			closeApprovalWindow();
+			setCopyStatus(null);
 			setPlexError("Could not reach Plex — try again.");
 		},
 	});
@@ -93,6 +163,7 @@ export function Login() {
 		if (pollData?.status === "ok") {
 			if (pollData.user == null) {
 				closeApprovalWindow();
+				setCopyStatus(null);
 				setPlexError("Plex sign-in failed — try again.");
 				setPin(null);
 				return;
@@ -110,6 +181,7 @@ export function Login() {
 	useEffect(() => {
 		if (pollError !== null) {
 			closeApprovalWindow();
+			setCopyStatus(null);
 			setPlexError(
 				pollError instanceof ApiError && pollError.status === 404
 					? "Plex sign-in expired — try again."
@@ -147,7 +219,7 @@ export function Login() {
 		>
 			<h1 className="text-4xl font-bold tracking-tight">Tasterr</h1>
 			<div className="flex w-full max-w-sm flex-col gap-6">
-				<div className="flex flex-col gap-2">
+				<div className="flex flex-col gap-2" aria-live="polite">
 					<button
 						type="button"
 						onClick={() => {
@@ -160,15 +232,40 @@ export function Login() {
 						{pin !== null ? "Waiting for Plex approval…" : "Sign in with Plex"}
 					</button>
 					{pin !== null && (
-						<p className="text-sm text-app-subtle">
-							Approve the sign-in in the Plex window, then come back here.{" "}
-							<button
-								type="button"
-								onClick={() => openApprovalWindow(pin.authUrl)}
+						<p
+							className={`text-sm ${popupFailed ? "text-status-error" : "text-app-subtle"}`}
+						>
+							{popupFailed
+								? "The Plex window isn't available — "
+								: "Approve the sign-in with Plex, then come back here. "}
+							<a
+								href={pin.authUrl}
+								target="_blank"
+								rel="noopener noreferrer"
 								className="underline"
 							>
-								Reopen the approval page
+								{popupFailed ? "open it here" : "Open the approval page"}
+							</a>
+							.{" "}
+							<button
+								type="button"
+								onClick={(event) =>
+									void copyApprovalUrl(pin.authUrl, event.currentTarget)
+								}
+								className="underline"
+							>
+								Copy approval URL
 							</button>
+						</p>
+					)}
+					{copyStatus !== null && (
+						<p
+							key={copyStatus.attempt}
+							className={`text-sm ${copyStatus.result === "failed" ? "text-status-error" : "text-app-subtle"}`}
+						>
+							{copyStatus.result === "copied"
+								? "Approval URL copied."
+								: "Could not copy the approval URL. Use the approval link instead."}
 						</p>
 					)}
 					{plexError !== null && (

--- a/frontend/src/routes/Login.tsx
+++ b/frontend/src/routes/Login.tsx
@@ -59,7 +59,11 @@ async function copyText(value: string): Promise<boolean> {
 		return false;
 	} finally {
 		textarea.remove();
-		activeElement?.focus();
+		try {
+			activeElement?.focus();
+		} catch {
+			// Focus restoration is best effort.
+		}
 	}
 }
 

--- a/openspec/changes/archive/2026-08-29-plex-approval-recovery/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-29-plex-approval-recovery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/archive/2026-08-29-plex-approval-recovery/design.md
+++ b/openspec/changes/archive/2026-08-29-plex-approval-recovery/design.md
@@ -1,0 +1,76 @@
+## Context
+
+See `proposal.md` for motivation. The current frontend already starts Plex login
+from a user-activated popup and polls independently, but its durable link-based
+recovery no longer matches the living contract's tracked replacement-popup
+language. Clipboard behavior also spans secure and plain-HTTP self-hosted
+deployments.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep popup handling best-effort and polling authoritative.
+- Make one BFF-provided approval URL usable through both a protected link and copy
+  action for the lifetime of the pending PIN.
+- Keep copy feedback current, repeatable, accessible, and focus-safe.
+
+**Non-Goals:**
+
+- Add a popup manager, clipboard dependency, or browser-specific recovery path.
+- Change backend auth, Plex PIN, polling, or session semantics.
+
+## Decisions
+
+### Use a durable link instead of tracking replacement popups
+
+The initial blank popup remains synchronous with the user's activation so popup
+blockers have the best chance to allow it. Once a PIN exists, the same
+backend-provided URL is always rendered as a link using a new browsing context
+with opener and referrer isolation. Polling never depends on either context.
+
+Tracking replacement windows was rejected because opener policies can sever the
+handle again, while the durable link works without coupling login completion to a
+browser window reference.
+
+### Keep the two native copy mechanisms
+
+Use the Clipboard API when available, then a temporary readonly textarea with the
+browser's native copy command. The fallback is fixed outside normal layout,
+removed in all outcomes, and restores the previously focused element. If both
+mechanisms fail, the durable link remains the recovery path.
+
+A dependency was rejected because the browser APIs require only a small local
+fallback and no package can override browser permission policy.
+
+### Treat each copy result as a separate live announcement
+
+Associate feedback with a monotonically increasing attempt number so repeated
+identical outcomes replace the status node. Publish a result only while its
+originating control remains connected, and clear feedback on every terminal PIN
+path.
+
+## Security considerations
+
+- The external approval URL continues to come from the BFF and is never assembled
+  client-side. Both link and popup paths prevent opener access; the link also
+  suppresses referrer data.
+- No credential, Plex token, session token, or approval URL is placed in browser
+  storage or logs. The existing HttpOnly session-cookie boundary is unchanged.
+- The frontend continues to render text normally; no HTML injection path is added.
+- Browser tests use invented URLs and make no live requests. No API endpoint,
+  outbound client, database, dependency, CSP, or response-header behavior changes.
+
+## Risks / Trade-offs
+
+- The legacy native copy command may eventually disappear → retain the protected
+  link and announce copy failure instead of hiding recovery.
+- Browser popup policies vary → keep popup work best-effort and make polling plus
+  the durable link authoritative.
+- Replacing the tracked reopen action changes the written contract → archive the
+  delta with the implementation so living specs and code stay atomic.
+
+## Migration Plan
+
+Deploy the frontend and synchronized living spec together. No data or API
+migration is required. Rollback is the repository squash commit.

--- a/openspec/changes/archive/2026-08-29-plex-approval-recovery/proposal.md
+++ b/openspec/changes/archive/2026-08-29-plex-approval-recovery/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The Plex approval fallback now uses a durable protected link instead of tracking a replacement popup, but the living authentication contract still requires the removed reopen behavior. Aligning the contract now keeps the recovery path reviewable and prevents future work from restoring the more fragile popup coupling.
+
+This advances the existing `user-auth` capability.
+
+## What Changes
+
+- Keep the initial script-created Plex approval popup as a best-effort convenience while polling remains authoritative.
+- Make a protected approval link and copy action available for every pending Plex PIN, including blocked, closed, or browser-severed popup cases.
+- Use neutral recovery guidance, focus-safe clipboard fallback, and repeatable accessible copy feedback.
+- Replace the tracked replacement-popup requirement with the durable link-based recovery contract and add focused regression coverage.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `user-auth`: Replace tracked approval-popup reopening with a durable protected approval link and copy fallback while preserving polling, opener isolation, and cleanup.
+
+## Impact
+
+The change affects the SPA login screen, its frontend tests, and the `user-auth` living specification. It changes no backend API, session boundary, dependency, or secret exposure.
+
+## Non-goals
+
+- Changing Plex PIN creation, polling, expiry, or session establishment.
+- Guaranteeing programmatic clipboard access when both browser clipboard mechanisms reject it.
+- Automating Plex's external approval page in the hermetic end-to-end suite.

--- a/openspec/changes/archive/2026-08-29-plex-approval-recovery/specs/user-auth/spec.md
+++ b/openspec/changes/archive/2026-08-29-plex-approval-recovery/specs/user-auth/spec.md
@@ -1,0 +1,103 @@
+## MODIFIED Requirements
+
+### Requirement: SPA login experience
+
+The login screen SHALL offer both paths: "Sign in with Plex" and a local
+email/password form. Plex sign-in SHALL attempt to open a script-created popup
+context directly from the user's activation, sever that context's access to its
+opener before navigating to the backend-provided Plex approval URL, and retain
+only an in-memory handle for best-effort cleanup. The SPA SHALL poll until
+completion and, when the browser still exposes the script-created context, close
+it and request focus for Tasterr after success.
+While a Plex PIN is pending, the SPA SHALL expose the backend-provided approval
+URL through a link that opens a new context without opener or referrer access and
+through a copy action. A blocked, manually closed, or browser-severed popup
+context SHALL NOT block polling, successful login, or either recovery action.
+Each completed copy attempt SHALL provide visible and assistive success or failure
+feedback, a fallback copy attempt SHALL restore the user's prior focus, and
+feedback from an ended approval flow SHALL NOT reappear.
+On success the SPA SHALL switch to the authenticated state without a full reload;
+a logout control SHALL end the session and return to the login screen. Failures
+SHALL surface as generic, human-readable messages. On each confirmed session
+transition — successful local login, successful Plex PIN completion, successful
+logout, or `auth/me` resolving to a different user — the SPA SHALL invalidate
+prior-session mutation callbacks, cancel in-flight TanStack Query requests before
+removing cached query data, and publish the confirmed user or signed-out state
+only after that boundary completes. Failed login or logout attempts SHALL preserve
+the current confirmed auth state and query cache.
+
+#### Scenario: Plex login from the SPA
+
+- **WHEN** the user starts Plex login, approves on plex.tv, and the browser retains
+  the script-created context handle
+- **THEN** the SPA detects completion via polling, closes that context, requests
+  focus for Tasterr, and shows the authenticated app
+
+#### Scenario: Plex approval cannot control Tasterr
+
+- **WHEN** Tasterr opens the backend-provided Plex approval URL in either the
+  script-created popup or the durable recovery link
+- **THEN** the approval context has no `opener` reference to the Tasterr tab
+
+#### Scenario: Approval context is unavailable
+
+- **WHEN** a popup blocker, manual close, or browser opener policy makes the
+  script-created approval context unavailable
+- **THEN** polling and successful login remain operable, and the protected
+  approval link and copy action remain available for the pending PIN
+
+#### Scenario: Approval URL copy succeeds repeatedly
+
+- **WHEN** the user copies the pending approval URL one or more times
+- **THEN** each successful attempt is announced visibly and to assistive
+  technology, and any fallback copy operation restores prior focus
+
+#### Scenario: Approval URL copy fails
+
+- **WHEN** the browser rejects both supported copy mechanisms
+- **THEN** the SPA announces a generic failure and leaves the protected approval
+  link available
+
+#### Scenario: Approval flow ends during copy
+
+- **WHEN** a copy operation completes after its pending PIN has expired or ended
+- **THEN** feedback from that obsolete approval flow does not reappear
+
+#### Scenario: Local login from the SPA
+
+- **WHEN** the user submits email and password accepted by Seerr
+- **THEN** the SPA shows the authenticated app
+
+#### Scenario: Logout from the SPA
+
+- **WHEN** the user activates logout
+- **THEN** the SPA returns to the login screen and the session is revoked
+
+#### Scenario: Shared browser changes household user
+
+- **WHEN** one household user logs out and another completes local or Plex login
+- **THEN** no cached response from the prior user renders while the new user's
+  responses are loading
+
+#### Scenario: Prior-session query completes late
+
+- **WHEN** an in-flight query from the prior session completes after a confirmed
+  session transition
+- **THEN** its response does not repopulate the active query cache
+
+#### Scenario: Current-user refresh detects a different identity
+
+- **WHEN** `auth/me` refetches after the browser session cookie changes from one
+  household user to another
+- **THEN** the prior user's query data is removed before the new identity renders
+
+#### Scenario: Prior-session mutation completes late
+
+- **WHEN** a mutation from the prior session completes after a confirmed session
+  transition
+- **THEN** its callback does not alter the active session's UI or cached queries
+
+#### Scenario: Auth transition fails
+
+- **WHEN** login or logout fails before a new session state is confirmed
+- **THEN** the SPA preserves the current confirmed auth state and cached data

--- a/openspec/changes/archive/2026-08-29-plex-approval-recovery/tasks.md
+++ b/openspec/changes/archive/2026-08-29-plex-approval-recovery/tasks.md
@@ -1,0 +1,7 @@
+## 1. Approval recovery
+
+- [x] 1.1 Keep approval guidance neutral, make copy feedback repeatable and stale-safe, keep the native fallback outside layout with focus restoration, clear terminal feedback, and verify these paths with focused Login tests including explicit clipboard absence and delayed completion after PIN expiry
+
+## 2. Validation
+
+- [x] 2.1 Run `just check` in the devcontainer and fix any failures

--- a/openspec/changes/archive/2026-08-29-richer-rails/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-29-richer-rails/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/archive/2026-08-29-richer-rails/design.md
+++ b/openspec/changes/archive/2026-08-29-richer-rails/design.md
@@ -1,0 +1,56 @@
+## Context
+
+See `proposal.md` for motivation. Service rails currently perform one cached TMDB movie discovery, while Plex already returns next-up episode rows that normalization discards when progress or the episode-level timestamp is absent. Both changes fit the current provider and typed-client boundaries.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve current rail composition and degradation contracts while using the movie, TV, and Plex hub data already available.
+- Keep ordering deterministic, bounded, and directly unit-testable.
+- Keep next-up episode context visible when progress is absent.
+- Avoid new endpoints, models exposed to the browser, dependencies, or durable data.
+
+**Non-Goals:**
+
+- Infer when a title arrived on a streaming service; TMDB release/first-air dates remain the only recency signal.
+- Change cross-rail de-duplication or Plex account/server validation.
+
+## Decisions
+
+### Fetch and interleave two service media types
+
+Each service provider will gather two `CatalogService.discover` calls with the same service, region-derived flatrate behavior, 365-day window, and vote floor. Movies use `primary_release_date.desc`; TV uses `first_air_date.desc`. A local wrapper catches `UpstreamError` per call so one failed leg still returns the other.
+
+A pure helper will alternate movie and TV results, then append the remaining side, capped by a local `SERVICE_RAIL_SIZE = 20`. This is smaller and easier to verify than teaching the composer about service-specific result groups. Sequential fetching was rejected because the calls are independent and would add latency.
+
+### Require service rails to be at least half full
+
+The service provider will set `min_items` to half of `SERVICE_RAIL_SIZE` (10). The global minimum of four remains correct for other providers, but a four-card service rail beside 20-card rails looks failed. Requiring 10 gives the service rail a simple, capacity-relative floor without changing composer behavior.
+
+### Admit only genuinely absent-progress next-up episodes
+
+Movies continue to require progress from 1 through 99. Episodes may carry null progress only when the upstream `viewOffset` field is absent; an explicitly supplied invalid, zero, or complete value remains ineligible. Pydantic's field-set metadata distinguishes an absent alias from a value that validation normalized to null.
+
+The typed PMS item gains `grandparentLastViewedAt` and `parentLastViewedAt`. All three optional ordering timestamps normalize malformed values to absent so one bad advisory field cannot discard a server's hub. Ordering uses `lastViewedAt`, then grandparent, then parent. When all are absent, an internal negative rank derived from the row's zero-based hub position sorts the row after timestamped items while preserving hub recency and deterministic server order. The rank is neither persisted nor returned. When duplicate show candidates have the same timestamp, an in-progress episode wins over a next-up episode before stable server order breaks any remaining tie.
+
+The existing `MediaSummary` already carries nullable progress and episode context. `MediaCard` will render context independently while continuing to omit the progress bar for null progress, so no response-model change is needed.
+
+## Security considerations
+
+- No endpoint, authentication, session, database, or browser response contract changes.
+- The existing typed Plex client still calls only validated PMS connections with the existing timeout, redirect policy, token header, account scoping, and 50-row bound. The optional ordering timestamp aliases retain only positive integers and otherwise normalize to absent; unknown upstream fields remain ignored.
+- TMDB discovery still routes only through `clients/`, uses validated settings, bounded timeouts, typed normalization, existing caching, and no browser headers. The extra call targets no new host.
+- Raw Plex payloads, viewing data, tokens, server URLs, and the internal fallback rank are not logged, cached as raw data, persisted, or returned.
+- Live verification remains opt-in and emits only generic exercised/skipped results. No dependency is added, so lockfiles and supply-chain review are unchanged.
+
+## Risks / Trade-offs
+
+- [Two TMDB calls per service double cold-cache discover work] → Keep the four-service cap and existing 45-minute discover cache; execute movie and TV legs concurrently.
+- [A catalog-heavy service may still look thin] → Omit fewer-than-10 results; widening the 365-day window remains a separate product decision.
+- [Plex timestamp fields vary by server/version] → Prefer three known fields and retain hub position as the final deterministic fallback; verify the real payload contract with the redacted live suite.
+- [Position ranks cannot compare exact recency across servers] → Sort all timestamped rows first, then interleave equal hub positions by stable server order; no stronger cross-server signal exists.
+
+## Migration Plan
+
+No migration is required. Deploy the code and spec together; rollback restores the prior movie-only service query and progress-required Continue Watching filter without data cleanup.

--- a/openspec/changes/archive/2026-08-29-richer-rails/proposal.md
+++ b/openspec/changes/archive/2026-08-29-richer-rails/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Selected-service rails can look broken when a recent movie-only query yields only a few titles, and Continue Watching omits Plex next-up episodes that the server already returns. Both gaps discard useful rail content already available from existing upstream contracts.
+
+## What Changes
+
+- Build each selected-service rail from recent flatrate movies and TV series, alternating media types and filling from either side up to 20 items.
+- Degrade a failed movie or TV service query independently and omit service rails that remain visibly under-filled.
+- Retain unwatched next-up episodes from Plex Continue Watching, order them by the best available episode/show timestamp, and preserve Plex hub order when no timestamp exists.
+- Show next-up episode context on cards even when no progress bar applies.
+- Keep progress-less movies excluded and keep existing progress validation for started items.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `media-browse`: Selected-service rails change from recent movies only to balanced recent movie/TV results with a service-specific fullness floor.
+- `plex-personalization`: Continue Watching eligibility and ordering expand to include next-up episodes without progress.
+
+## Impact
+
+- Advances the existing M2 Browse service-rail capability and the v2 Plex Continue Watching capability.
+- Changes rail composition in `backend/src/tasterr/rails/registry.py`, Plex normalization and typed PMS item fields, and context rendering in `frontend/src/components/MediaCard.tsx`.
+- Adds one TMDB discover call per configured service rail; existing discover caching and the four-service cap remain unchanged.
+- No API model, database, migration, or dependency changes.
+
+## Non-goals
+
+- Widening the 365-day service-release window or treating TMDB release dates as service-arrival dates.
+- Adding Plex endpoints or persisting raw Plex data.
+- Changing general rail de-duplication, global rail ordering, or the four-service limit.

--- a/openspec/changes/archive/2026-08-29-richer-rails/specs/media-browse/spec.md
+++ b/openspec/changes/archive/2026-08-29-richer-rails/specs/media-browse/spec.md
@@ -1,0 +1,141 @@
+## MODIFIED Requirements
+
+### Requirement: Home feed of a hero and composed rails
+
+`GET /api/v1/home` SHALL return the enabled hero section and an ordered list of
+enabled rails, each a titled list of media summaries. The global runtime snapshot
+SHALL gate registered provider types before they fetch. The provider set SHALL
+include non-personalized trending, popular-in-region, recent-release, genre, and
+bounded per-selected-service rails plus the authenticated caller's
+`continue-watching`, `recommended-for-you`, `more-like`, `my-list`, and
+`unexpected-picks` providers. The separately requested `household-blend` rail
+SHALL NOT be part
+of this response. The generic release rail SHALL be titled `Recent Releases`.
+Each per-selected-service rail SHALL use current flatrate movie and TV
+availability, movie release dates and TV first-air dates from the preceding 365
+days, and SHALL be titled `Recent Releases on {service}`. Service results SHALL
+alternate movie and TV while both have items, append the remaining media type
+when one side is exhausted, and contain no more than 20 items. A service rail
+with fewer than 10 items after normal de-duplication SHALL be omitted. Dynamic
+genre and service instances share their registered type gate; absent disablement
+means enabled, including for a newly registered type. A provider failure SHALL
+degrade the feed to fewer rails rather than fail the request, and rails with
+fewer than a minimum number of items SHALL be omitted. Titles SHALL be
+de-duplicated across rails in the initial `/home` response so a title does not
+repeat later there. Paginated `/rails` results SHALL remove duplicates within
+each individual rail but SHALL NOT strip a provider's items because the same
+title occurs in another extra rail; overlap across service, decade, and genre
+rails is allowed because the stateless cursor does not carry a cross-page
+seen-title set. Disabling every provider SHALL return a valid empty feed rather
+than override the admin's choice.
+
+The visible Home sequence SHALL preserve this relative order among available
+rails: Continue Watching, My List, Recommended for You, Trending Now, More Like
+X/Because You Watched X, Popular Movies, Popular TV, Recent Releases, Picks You
+Wouldn't Usually Watch, Top Rated Movies, Top Rated TV, selected-service rails,
+decades, then genres. Genre rails SHALL mix movie and TV providers in a per-user
+daily-stable order after decades, using explicit **{Genre} · Movies** and
+**{Genre} · TV** labels. Stable order SHALL be reused across cursor pages for that
+user/day; no presentation seed SHALL be persisted.
+
+#### Scenario: Authenticated home returns enabled hero and rails
+
+- **WHEN** an authenticated client requests `GET /api/v1/home` with default
+  settings
+- **THEN** it receives a hero and an ordered set of non-empty rails
+
+#### Scenario: Disabled type is neither fetched nor returned
+
+- **WHEN** an admin has disabled a registered hero or rail type
+- **THEN** that section/provider performs no catalog or upstream capability work
+  and is absent from the feed
+
+#### Scenario: New provider type defaults enabled
+
+- **WHEN** a registered type has no entry in the disabled set
+- **THEN** it participates in composition by default
+
+#### Scenario: Generic release rail is labelled honestly
+
+- **WHEN** the generic release provider yields enough movie titles
+- **THEN** the home feed includes a `Recent Releases` rail
+
+#### Scenario: Selected service produces a bounded service rail
+
+- **WHEN** a selected service has provider metadata and enough recent flatrate
+  movie and TV titles
+- **THEN** the home feed includes a `Recent Releases on {service}` rail that
+  alternates movies and TV and contains no more than 20 items
+
+#### Scenario: Lopsided service results fill from the available side
+
+- **WHEN** one media type has fewer recent service titles than the other
+- **THEN** the rail alternates while both have items and fills its remaining
+  capacity from the media type with surplus titles
+
+#### Scenario: Service media-type failure degrades independently
+
+- **WHEN** either the movie or TV discovery call for a selected service fails
+- **THEN** the other media type may still produce the service rail when it meets
+  the service fullness floor
+
+#### Scenario: Service metadata failure degrades independently
+
+- **WHEN** provider metadata cannot be resolved and no stale value exists
+- **THEN** service rails are omitted while other home providers still compose
+
+#### Scenario: One failing provider still returns the rest
+
+- **WHEN** a single rail provider errors while composing the home feed
+- **THEN** the response still contains the enabled hero and remaining rails
+
+#### Scenario: Under-filled rail omitted
+
+- **WHEN** a provider yields fewer than the minimum number of items
+- **THEN** that rail is omitted from the feed
+
+#### Scenario: Under-filled service rail omitted
+
+- **WHEN** a selected-service provider yields fewer than 10 distinct items
+- **THEN** that service rail is omitted rather than rendered as a visibly
+  stunted row
+
+#### Scenario: Titles de-duplicated across rails
+
+- **WHEN** a title qualifies for more than one rail in a single Home response
+- **THEN** it appears in only the earliest returned rail
+
+#### Scenario: Cursor grouping does not shrink extra rails
+
+- **WHEN** two paginated service, decade, or genre providers contain overlapping
+  titles and happen to share one cursor response
+- **THEN** each rail retains its own distinct provider results just as it would on
+  separate cursor pages
+
+#### Scenario: Home preserves the approved rail sequence
+
+- **WHEN** every provider yields enough distinct items
+- **THEN** the visible rails follow the specified personalized, broad catalog,
+  service, decade, and mixed-genre order
+
+#### Scenario: Daily genre variation is cursor-stable
+
+- **WHEN** one user loads multiple genre cursor pages on the same day
+- **THEN** movie and TV genre rails use one stable mixed order with no per-request
+  reshuffle
+
+#### Scenario: Home is personalized per user
+
+- **WHEN** two users with different taste profiles request `GET /api/v1/home`
+- **THEN** each receives enabled personalized rails reflecting their own profile
+
+#### Scenario: Signal-less user sees the non-personalized home
+
+- **WHEN** a user with no signals requests the home feed
+- **THEN** the response contains enabled non-personalized rails and no
+  personalized rail placeholders
+
+#### Scenario: Every section disabled returns a valid empty feed
+
+- **WHEN** the admin disables hero and every registered rail type
+- **THEN** the endpoint returns 200 with an empty hero/rail result

--- a/openspec/changes/archive/2026-08-29-richer-rails/specs/plex-personalization/spec.md
+++ b/openspec/changes/archive/2026-08-29-richer-rails/specs/plex-personalization/spec.md
@@ -1,0 +1,133 @@
+## MODIFIED Requirements
+
+### Requirement: Continue Watching composes as a capability-gated rail
+
+For a Plex-backed session with the rail type enabled, the home composer SHALL add
+`continue-watching` titled **Continue Watching** ahead of the other personalized
+providers. It SHALL read bounded items from
+`MediaContainer.Hub[].Metadata` on each validated server, retain only
+account-scoped in-progress movie items and eligible in-progress or next-up
+episode items, order them by the first available item, show, or season
+last-viewed timestamp and deterministic resource/input order, de-duplicate equal
+per-server rating keys, and let at most the first `RAIL_SIZE = 20` enter Plex
+metadata/GUID expansion. A next-up episode with none of those timestamps SHALL
+remain eligible in its server-provided hub position rather than be dropped.
+Those candidates SHALL then be canonically mapped/merged and no more than 20
+SHALL enter browser-facing TMDB resolution. Each server hub SHALL return at most
+50 items. The complete load SHALL have a ten-second wall-clock deadline. Final
+secret-free results SHALL be cached per user for five minutes. A failed/timed-out
+load SHALL replace the result with an empty negative entry for five minutes;
+stale-on-error SHALL NOT be used. Plex capability gating SHALL happen before
+cache access. Raw Plex payloads, server connections, and access tokens SHALL NOT
+be cached. The provider SHALL use no request DB session and SHALL compose non-
+exclusively; its declared response order SHALL remain first among personalized
+providers.
+
+Progress SHALL equal `floor(100 * view_offset / duration)` when the offset is
+finite and non-negative and duration is finite and positive. Started items SHALL
+be included only when the result is from 1 through 99; zero, complete, and
+invalid progress SHALL omit the item rather than clamp it. Missing progress SHALL
+omit a movie, but an episode with an absent view offset MAY be included as a
+next-up item with null progress. A valid episode MAY carry locally generated
+`S{season} E{episode}` context. A card with that context SHALL display it even
+when progress is null, while omitting the progress bar. The provider SHALL use
+the existing minimum-size, cross-rail de-duplication, and
+independent-degradation behavior.
+
+#### Scenario: Progress is calculated deterministically
+
+- **WHEN** a resumable item has view offset 5 and duration 8
+- **THEN** its progress is 62 percent
+
+#### Scenario: Plex-backed user sees resumable titles
+
+- **WHEN** an enabled Plex-backed user has enough canonically mapped in-progress
+  movies, in-progress episodes, or next-up episodes
+- **THEN** Home begins its personalized rails with one de-duplicated Continue
+  Watching rail of TMDB-backed summaries
+
+#### Scenario: Next-up episode uses show activity timestamp
+
+- **WHEN** an episode has no view offset or item last-viewed timestamp but has a
+  show or season last-viewed timestamp
+- **THEN** it remains eligible with null progress and uses the first available
+  show or season timestamp for ordering
+
+#### Scenario: Next-up episode falls back to Plex hub position
+
+- **WHEN** an episode has no view offset and no item, show, or season last-viewed
+  timestamp
+- **THEN** it remains eligible with null progress in the relative recency order
+  supplied by its server's Continue Watching hub
+
+#### Scenario: Progress-less movie remains excluded
+
+- **WHEN** a movie has no valid in-progress percentage
+- **THEN** it is omitted from Continue Watching
+
+#### Scenario: Next-up card shows episode context without progress
+
+- **WHEN** an eligible next-up episode has local season and episode context but
+  null progress
+- **THEN** its card displays the context without rendering a progress bar
+
+#### Scenario: Continue Watching work is capped before TMDB
+
+- **WHEN** four servers each expose more than 50 eligible hub items
+- **THEN** at most 50 items per server are read, at most 20 newest eligible rows
+  enter Plex metadata expansion, and at most 20 merged canonical items enter TMDB
+  resolution
+
+#### Scenario: Fetch concurrency does not change response priority
+
+- **WHEN** Continue Watching and other non-exclusive providers compose together
+- **THEN** their fetches may overlap while a successful Continue Watching rail
+  still appears first among personalized results
+
+#### Scenario: Duplicate episode sources merge to a show
+
+- **WHEN** several servers or episodes resolve to the same TMDB series
+- **THEN** one series card remains from the newest available activity timestamp,
+  preferring non-null progress on an equal timestamp before server hub and
+  deterministic resource order break any remaining tie
+
+#### Scenario: Tokenless or disabled capability performs no work
+
+- **WHEN** the session lacks a Plex token or the admin disabled Continue Watching
+- **THEN** no Plex read runs and no empty rail placeholder is returned
+
+#### Scenario: Plex failure does not fail Home
+
+- **WHEN** plex.tv or every accessible PMS is unavailable and no cached result is
+  usable
+- **THEN** Continue Watching is omitted while the remaining Home feed returns
+
+#### Scenario: Hanging Continue Watching is negatively cached
+
+- **WHEN** the aggregate Plex load exceeds ten seconds
+- **THEN** Home omits the rail, returns normally, and another request within five
+  minutes performs no Plex retry
+
+#### Scenario: Recovered Continue Watching replaces a negative entry
+
+- **WHEN** Plex recovers after a five-minute negative cache entry expires
+- **THEN** the next eligible load may populate and cache the caller's rail
+
+#### Scenario: Failed refresh does not serve stale progress
+
+- **WHEN** a successful five-minute entry expires and its refresh fails
+- **THEN** the expired value is not served and an empty negative entry replaces it
+
+#### Scenario: Plex sessions share one user cache entry
+
+- **WHEN** two Plex-backed sessions for the same Tasterr user request Home during
+  one cache lifetime
+- **THEN** they use the same caller-scoped Continue Watching result without a
+  second Plex load
+
+#### Scenario: Continue Watching is isolated to the caller
+
+- **WHEN** an owner-capable token's hub cannot be proven scoped or filtered to the
+  validated account
+- **THEN** Continue Watching is skipped for that token and no other user's
+  progress can appear

--- a/openspec/changes/archive/2026-08-29-richer-rails/tasks.md
+++ b/openspec/changes/archive/2026-08-29-richer-rails/tasks.md
@@ -1,0 +1,20 @@
+## 1. Mixed service rails
+
+- [x] 1.1 Fetch recent flatrate movies and TV independently, interleave them to 20 with surplus fill, require 10 final items, and verify balanced, lopsided, query-parameter, cap, and one-leg-failure cases in `backend/tests/test_rails.py`
+
+## 2. Plex next-up episodes
+
+- [x] 2.1 Parse show/season last-viewed timestamps, retain only episodes whose progress is genuinely absent, preserve hub position as the final ordering fallback, allow null progress through summary mapping, and verify timestamp, position, invalid-progress, and progress-less-movie behavior in `backend/tests/test_catalog_plex.py`
+- [x] 2.2 Update the redacted live Plex timestamp contract for next-up rows and run `just test-live`, reporting only generic timestamp-field/fallback findings
+
+## 3. Validation
+
+- [x] 3.1 Run `openspec validate richer-rails --strict` and fix all change-artifact errors
+- [x] 3.2 Run `just check` and fix all failures
+
+## 4. Review fixes
+
+- [x] 4.1 Render next-up episode context without a progress bar and cover it in `MediaCard.test.tsx`
+- [x] 4.2 Normalize malformed optional Plex ordering timestamps, prefer in-progress duplicates on timestamp ties, and cover timestamp priority, malformed inputs, explicit-null progress, and cross-server fallback order
+- [x] 4.3 Cover the service-specific 10-item omission through the composer
+- [x] 4.4 Re-run strict OpenSpec validation and `just check`

--- a/openspec/specs/dev-tooling/spec.md
+++ b/openspec/specs/dev-tooling/spec.md
@@ -61,8 +61,8 @@ produces, failing when they have drifted out of sync.
 
 ### Requirement: Devcontainer runs the gate without host dependencies
 The repo SHALL provide a `.devcontainer/` configuration that supplies the full
-toolchain (uv, node, just) in a Linux container with the repository bind-mounted
-from the local working copy. Dependency trees (`backend/.venv`,
+toolchain (uv, node, just, GitHub CLI, OpenSpec) in a Linux container with the
+repository bind-mounted from the local working copy. Dependency trees (`backend/.venv`,
 `frontend/node_modules`) MUST live on container volumes, not the host filesystem.
 `just check` inside the devcontainer MUST be the same command and gate as on the
 host and in CI.
@@ -151,4 +151,3 @@ credentials or publish images.
 #### Scenario: Pull request cannot publish a package
 - **WHEN** untrusted pull-request code executes in CI
 - **THEN** its workflow token has no package-write permission and no publish step runs
-

--- a/openspec/specs/media-browse/spec.md
+++ b/openspec/specs/media-browse/spec.md
@@ -2,7 +2,9 @@
 
 ## Purpose
 TBD - created by archiving change m2-browse. Update Purpose after archive.
+
 ## Requirements
+
 ### Requirement: Home feed of a hero and composed rails
 
 `GET /api/v1/home` SHALL return the enabled hero section and an ordered list of
@@ -14,19 +16,23 @@ bounded per-selected-service rails plus the authenticated caller's
 `unexpected-picks` providers. The separately requested `household-blend` rail
 SHALL NOT be part
 of this response. The generic release rail SHALL be titled `Recent Releases`.
-Each per-selected-service rail SHALL use current flatrate movie availability and
-movie release dates from the preceding 365 days and SHALL be titled
-`Recent Releases on {service}`. Dynamic genre and service instances share their
-registered type gate; absent disablement means enabled, including for a newly
-registered type. A provider failure SHALL degrade the feed to fewer rails rather
-than fail the request, and rails with fewer than a minimum number of items SHALL
-be omitted. Titles SHALL be de-duplicated across rails in the initial `/home`
-response so a title does not repeat later there. Paginated `/rails` results SHALL
-remove duplicates within each individual rail but SHALL NOT strip a provider's
-items because the same title occurs in another extra rail; overlap across service,
-decade, and genre rails is allowed because the stateless cursor does not carry a
-cross-page seen-title set. Disabling every provider SHALL return a valid empty
-feed rather than override the admin's choice.
+Each per-selected-service rail SHALL use current flatrate movie and TV
+availability, movie release dates and TV first-air dates from the preceding 365
+days, and SHALL be titled `Recent Releases on {service}`. Service results SHALL
+alternate movie and TV while both have items, append the remaining media type
+when one side is exhausted, and contain no more than 20 items. A service rail
+with fewer than 10 items after normal de-duplication SHALL be omitted. Dynamic
+genre and service instances share their registered type gate; absent disablement
+means enabled, including for a newly registered type. A provider failure SHALL
+degrade the feed to fewer rails rather than fail the request, and rails with
+fewer than a minimum number of items SHALL be omitted. Titles SHALL be
+de-duplicated across rails in the initial `/home` response so a title does not
+repeat later there. Paginated `/rails` results SHALL remove duplicates within
+each individual rail but SHALL NOT strip a provider's items because the same
+title occurs in another extra rail; overlap across service, decade, and genre
+rails is allowed because the stateless cursor does not carry a cross-page
+seen-title set. Disabling every provider SHALL return a valid empty feed rather
+than override the admin's choice.
 
 The visible Home sequence SHALL preserve this relative order among available
 rails: Continue Watching, My List, Recommended for You, Trending Now, More Like
@@ -61,10 +67,22 @@ user/day; no presentation seed SHALL be persisted.
 
 #### Scenario: Selected service produces a bounded service rail
 
-- **WHEN** a selected service has provider metadata and enough flatrate movie
-  titles released during the preceding 365 days
-- **THEN** the home feed includes a `Recent Releases on {service}` rail for it,
-  up to the documented service-rail cap
+- **WHEN** a selected service has provider metadata and enough recent flatrate
+  movie and TV titles
+- **THEN** the home feed includes a `Recent Releases on {service}` rail that
+  alternates movies and TV and contains no more than 20 items
+
+#### Scenario: Lopsided service results fill from the available side
+
+- **WHEN** one media type has fewer recent service titles than the other
+- **THEN** the rail alternates while both have items and fills its remaining
+  capacity from the media type with surplus titles
+
+#### Scenario: Service media-type failure degrades independently
+
+- **WHEN** either the movie or TV discovery call for a selected service fails
+- **THEN** the other media type may still produce the service rail when it meets
+  the service fullness floor
 
 #### Scenario: Service metadata failure degrades independently
 
@@ -80,6 +98,12 @@ user/day; no presentation seed SHALL be persisted.
 
 - **WHEN** a provider yields fewer than the minimum number of items
 - **THEN** that rail is omitted from the feed
+
+#### Scenario: Under-filled service rail omitted
+
+- **WHEN** a selected-service provider yields fewer than 10 distinct items
+- **THEN** that service rail is omitted rather than rendered as a visibly
+  stunted row
 
 #### Scenario: Titles de-duplicated across rails
 

--- a/openspec/specs/plex-personalization/spec.md
+++ b/openspec/specs/plex-personalization/spec.md
@@ -2,7 +2,9 @@
 
 ## Purpose
 TBD - created by archiving change v2-plex-aware-personalization. Update Purpose after archive.
+
 ## Requirements
+
 ### Requirement: Plex media reads use only the caller's protected session material
 
 For a Plex-backed authenticated session, the system SHALL decrypt that session's
@@ -268,27 +270,33 @@ For a Plex-backed session with the rail type enabled, the home composer SHALL ad
 `continue-watching` titled **Continue Watching** ahead of the other personalized
 providers. It SHALL read bounded items from
 `MediaContainer.Hub[].Metadata` on each validated server, retain only
-account-scoped resumable movie/episode items, order them by newest validated
+account-scoped in-progress movie items and eligible in-progress or next-up
+episode items, order them by the first available item, show, or season
 last-viewed timestamp and deterministic resource/input order, de-duplicate equal
 per-server rating keys, and let at most the first `RAIL_SIZE = 20` enter Plex
-metadata/GUID expansion. Those candidates SHALL
-then be canonically mapped/merged and no more than 20 SHALL enter browser-facing
-TMDB resolution. Each server hub SHALL return at most 50 items. The complete load
-SHALL have a ten-second wall-clock deadline. Final
+metadata/GUID expansion. A next-up episode with none of those timestamps SHALL
+remain eligible in its server-provided hub position rather than be dropped.
+Those candidates SHALL then be canonically mapped/merged and no more than 20
+SHALL enter browser-facing TMDB resolution. Each server hub SHALL return at most
+50 items. The complete load SHALL have a ten-second wall-clock deadline. Final
 secret-free results SHALL be cached per user for five minutes. A failed/timed-out
 load SHALL replace the result with an empty negative entry for five minutes;
-stale-on-error SHALL NOT be used. Plex capability gating SHALL happen before cache
-access. Raw Plex payloads, server connections, and access tokens SHALL NOT be
-cached. The provider SHALL use no request DB session and SHALL compose non-
+stale-on-error SHALL NOT be used. Plex capability gating SHALL happen before
+cache access. Raw Plex payloads, server connections, and access tokens SHALL NOT
+be cached. The provider SHALL use no request DB session and SHALL compose non-
 exclusively; its declared response order SHALL remain first among personalized
 providers.
 
 Progress SHALL equal `floor(100 * view_offset / duration)` when the offset is
-finite and non-negative and duration is finite and positive. Only results from 1
-through 99 SHALL be included; zero, complete, missing, and invalid progress SHALL
-omit the item rather than clamp it. A valid episode MAY carry locally generated
-`S{season} E{episode}` context. The provider SHALL use the existing minimum-size,
-cross-rail de-duplication, and independent-degradation behavior.
+finite and non-negative and duration is finite and positive. Started items SHALL
+be included only when the result is from 1 through 99; zero, complete, and
+invalid progress SHALL omit the item rather than clamp it. Missing progress SHALL
+omit a movie, but an episode with an absent view offset MAY be included as a
+next-up item with null progress. A valid episode MAY carry locally generated
+`S{season} E{episode}` context. A card with that context SHALL display it even
+when progress is null, while omitting the progress bar. The provider SHALL use
+the existing minimum-size, cross-rail de-duplication, and
+independent-degradation behavior.
 
 #### Scenario: Progress is calculated deterministically
 
@@ -298,13 +306,38 @@ cross-rail de-duplication, and independent-degradation behavior.
 #### Scenario: Plex-backed user sees resumable titles
 
 - **WHEN** an enabled Plex-backed user has enough canonically mapped in-progress
-  movies or episodes
+  movies, in-progress episodes, or next-up episodes
 - **THEN** Home begins its personalized rails with one de-duplicated Continue
   Watching rail of TMDB-backed summaries
 
+#### Scenario: Next-up episode uses show activity timestamp
+
+- **WHEN** an episode has no view offset or item last-viewed timestamp but has a
+  show or season last-viewed timestamp
+- **THEN** it remains eligible with null progress and uses the first available
+  show or season timestamp for ordering
+
+#### Scenario: Next-up episode falls back to Plex hub position
+
+- **WHEN** an episode has no view offset and no item, show, or season last-viewed
+  timestamp
+- **THEN** it remains eligible with null progress in the relative recency order
+  supplied by its server's Continue Watching hub
+
+#### Scenario: Progress-less movie remains excluded
+
+- **WHEN** a movie has no valid in-progress percentage
+- **THEN** it is omitted from Continue Watching
+
+#### Scenario: Next-up card shows episode context without progress
+
+- **WHEN** an eligible next-up episode has local season and episode context but
+  null progress
+- **THEN** its card displays the context without rendering a progress bar
+
 #### Scenario: Continue Watching work is capped before TMDB
 
-- **WHEN** four servers each expose more than 50 resumable hub items
+- **WHEN** four servers each expose more than 50 eligible hub items
 - **THEN** at most 50 items per server are read, at most 20 newest eligible rows
   enter Plex metadata expansion, and at most 20 merged canonical items enter TMDB
   resolution
@@ -318,8 +351,9 @@ cross-rail de-duplication, and independent-degradation behavior.
 #### Scenario: Duplicate episode sources merge to a show
 
 - **WHEN** several servers or episodes resolve to the same TMDB series
-- **THEN** one series card remains from the newest last-viewed timestamp, with
-  deterministic resource order breaking a tie
+- **THEN** one series card remains from the newest available activity timestamp,
+  preferring non-null progress on an equal timestamp before server hub and
+  deterministic resource order break any remaining tie
 
 #### Scenario: Tokenless or disabled capability performs no work
 

--- a/openspec/specs/user-auth/spec.md
+++ b/openspec/specs/user-auth/spec.md
@@ -2,7 +2,9 @@
 
 ## Purpose
 TBD - created by archiving change m1-auth. Update Purpose after archive.
+
 ## Requirements
+
 ### Requirement: Plex PIN login flow
 The system SHALL implement Plex PIN login. `POST /api/v1/auth/plex/pin` creates a
 PIN at plex.tv (product `Tasterr`, a stable client identifier) and returns an
@@ -212,23 +214,28 @@ browser headers upstream or upstream headers/bodies downstream.
 ### Requirement: SPA login experience
 
 The login screen SHALL offer both paths: "Sign in with Plex" and a local
-email/password form. Plex sign-in SHALL open a script-created popup context
-directly from the user's activation, sever that context's access to its opener
-before navigating to the backend-provided Plex approval URL, and retain only an
-in-memory handle for best-effort cleanup. The SPA SHALL poll until completion and,
-when the browser still exposes the script-created context, close it and request
-focus for Tasterr after success.
-A blocked, manually closed, or browser-severed context SHALL NOT block polling or
-successful login, and the user SHALL be able to reopen a new protected approval
-context. On success the SPA SHALL switch to the authenticated state without a full
-reload; a logout control SHALL end the session and return to the login screen.
-Failures SHALL surface as generic, human-readable messages. On each confirmed
-session transition — successful local login, successful Plex PIN completion,
-successful logout, or `auth/me` resolving to a different user — the SPA SHALL
-invalidate prior-session mutation callbacks, cancel in-flight TanStack Query
-requests before removing cached query data, and publish the confirmed user or
-signed-out state only after that boundary completes. Failed login or logout
-attempts SHALL preserve the current confirmed auth state and query cache.
+email/password form. Plex sign-in SHALL attempt to open a script-created popup
+context directly from the user's activation, sever that context's access to its
+opener before navigating to the backend-provided Plex approval URL, and retain
+only an in-memory handle for best-effort cleanup. The SPA SHALL poll until
+completion and, when the browser still exposes the script-created context, close
+it and request focus for Tasterr after success.
+While a Plex PIN is pending, the SPA SHALL expose the backend-provided approval
+URL through a link that opens a new context without opener or referrer access and
+through a copy action. A blocked, manually closed, or browser-severed popup
+context SHALL NOT block polling, successful login, or either recovery action.
+Each completed copy attempt SHALL provide visible and assistive success or failure
+feedback, a fallback copy attempt SHALL restore the user's prior focus, and
+feedback from an ended approval flow SHALL NOT reappear.
+On success the SPA SHALL switch to the authenticated state without a full reload;
+a logout control SHALL end the session and return to the login screen. Failures
+SHALL surface as generic, human-readable messages. On each confirmed session
+transition — successful local login, successful Plex PIN completion, successful
+logout, or `auth/me` resolving to a different user — the SPA SHALL invalidate
+prior-session mutation callbacks, cancel in-flight TanStack Query requests before
+removing cached query data, and publish the confirmed user or signed-out state
+only after that boundary completes. Failed login or logout attempts SHALL preserve
+the current confirmed auth state and query cache.
 
 #### Scenario: Plex login from the SPA
 
@@ -239,15 +246,33 @@ attempts SHALL preserve the current confirmed auth state and query cache.
 
 #### Scenario: Plex approval cannot control Tasterr
 
-- **WHEN** Tasterr navigates its script-created context to the Plex approval URL
-- **THEN** the child context has no `opener` reference to the Tasterr tab
+- **WHEN** Tasterr opens the backend-provided Plex approval URL in either the
+  script-created popup or the durable recovery link
+- **THEN** the approval context has no `opener` reference to the Tasterr tab
 
 #### Scenario: Approval context is unavailable
 
 - **WHEN** a popup blocker, manual close, or browser opener policy makes the
-  approval context unavailable
-- **THEN** polling and successful login remain operable, and the reopen action can
-  create and track a replacement context
+  script-created approval context unavailable
+- **THEN** polling and successful login remain operable, and the protected
+  approval link and copy action remain available for the pending PIN
+
+#### Scenario: Approval URL copy succeeds repeatedly
+
+- **WHEN** the user copies the pending approval URL one or more times
+- **THEN** each successful attempt is announced visibly and to assistive
+  technology, and any fallback copy operation restores prior focus
+
+#### Scenario: Approval URL copy fails
+
+- **WHEN** the browser rejects both supported copy mechanisms
+- **THEN** the SPA announces a generic failure and leaves the protected approval
+  link available
+
+#### Scenario: Approval flow ends during copy
+
+- **WHEN** a copy operation completes after its pending PIN has expired or ended
+- **THEN** feedback from that obsolete approval flow does not reappear
 
 #### Scenario: Local login from the SPA
 


### PR DESCRIPTION
## What / why

Consolidate the reviewed devcontainer tooling, Plex approval recovery, and richer-rail changes so the original PRs remain unchanged. Add container-managed GitHub CLI and OpenSpec tooling, keep Plex sign-in recoverable through a durable protected approval link and resilient copy feedback, and enrich selected-service and Continue Watching rails with bounded mixed-media and next-up behavior.

This follow-up reconciles the living user-auth contract with link-based recovery, strengthens stale-copy and timestamp-priority regression coverage, and removes a live-test assumption about Plex's upstream ordering. Supersedes #22, #23, and #24.

## Spec

- OpenSpec changes: `richer-rails`, `plex-approval-recovery`
- [x] Changes archived on this branch

## Checklist

- [x] `just check` passes locally
- [x] Title is the Conventional Commit subject for the squash
