### PR TITLE
fix: encode Plex history bounds correctly

### DIFF
--- a/backend/src/tasterr/clients/plex.py
+++ b/backend/src/tasterr/clients/plex.py
@@ -385,8 +385,8 @@ class PlexMediaClient:
                 params={
                     "accountID": str(account_id),
                     "sort": "viewedAt:desc",
-                    "viewedAt>=": str(viewed_after),
-                    "viewedAt<=": str(viewed_before),
+                    "viewedAt>": str(viewed_after),
+                    "viewedAt<": str(viewed_before),
                 },
                 headers={
                     "X-Plex-Container-Start": str(start),

--- a/backend/tests/live/test_plex_live.py
+++ b/backend/tests/live/test_plex_live.py
@@ -286,8 +286,8 @@ async def test_history_is_account_filtered_isolated_and_paged() -> None:
             params = {
                 "accountID": str(state.account_id),
                 "sort": "viewedAt:desc",
-                "viewedAt>=": str(after),
-                "viewedAt<=": str(now),
+                "viewedAt>": str(after),
+                "viewedAt<": str(now),
             }
             headers = _headers(state.server.access_token.get_secret_value())
             try:

--- a/backend/tests/test_clients_plex.py
+++ b/backend/tests/test_clients_plex.py
@@ -640,8 +640,8 @@ async def test_history_is_filtered_ordered_and_paged() -> None:
         assert request.url.path == "/status/sessions/history/all"
         assert request.url.params["accountID"] == "42"
         assert request.url.params["sort"] == "viewedAt:desc"
-        assert request.url.params["viewedAt>="] == "1000"
-        assert request.url.params["viewedAt<="] == "2000"
+        assert request.url.params["viewedAt>"] == "1000"
+        assert request.url.params["viewedAt<"] == "2000"
         start = int(request.headers["x-plex-container-start"])
         starts.append(start)
         count = 100 if start == 0 else 1


### PR DESCRIPTION
## What / why

Encode Plex playback-history comparison operators as URL query keys without the delimiter equals sign. The previous keys produced an extra equals in the request, so PMS ignored the requested time window and the client rejected valid history responses as out of range.

Update focused and live-contract assertions for the actual Plex query grammar.

## Spec

- OpenSpec change: n/a (bug fix restoring the existing 365-day history contract)

## Checklist

- [x] just check passes locally
- [x] Plex live contracts pass with fresh owner, managed, and shared tokens
- [x] Title is the Conventional Commit subject for the squash