### PR TITLE
chore: prepare v2.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ values listed above. Pin the desired version from the
 ```yaml
 services:
   tasterr:
-    image: ghcr.io/zacharyarthur/tasterr:2.0.0
+    image: ghcr.io/zacharyarthur/tasterr:2.1.0
     restart: unless-stopped
     ports:
       - "127.0.0.1:8000:8000"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,10 @@
 
 | Version | Supported |
 |---|---|
-| 2.0.x | Yes |
+| 2.1.x | Yes |
 | Pre-release and older builds | No |
 
-Security fixes are made on the current stable 2.0 line. Upgrade to the newest patch
+Security fixes are made on the current stable 2.1 line. Upgrade to the newest patch
 release before reporting an issue that may already be fixed.
 
 ## Report a vulnerability privately

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tasterr"
-version = "2.0.0"
+version = "2.1.0"
 description = "Self-hosted, Netflix-style discovery front-end for a household media stack"
 license = "AGPL-3.0-only"
 requires-python = ">=3.13"

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -56,7 +56,7 @@ def test_readme_links_every_living_operator_document() -> None:
     assert "A shared Docker network is not required" in readme
     assert "TASTERR_HTTP_PORT=8000" in readme
     assert "github.com/ZacharyArthur/tasterr/actions/workflows/gate.yml/badge.svg" in readme
-    assert "image: ghcr.io/zacharyarthur/tasterr:2.0.0" in readme
+    assert "image: ghcr.io/zacharyarthur/tasterr:2.1.0" in readme
     assert '- "127.0.0.1:8000:8000"' in readme
     assert "tasterr-data:/data" in readme
     assert "does not require a\n`.env` file" in readme
@@ -81,12 +81,12 @@ def test_readme_links_every_living_operator_document() -> None:
     assert "This is a Compose concern, not an application requirement" in configuration
 
     releasing = _read(DOCS / "RELEASING.md")
-    evidence = _read(DOCS / "releases" / "v2.0.0.md")
+    evidence = _read(DOCS / "releases" / "v2.1.0.md")
     assert "OWNER/REPOSITORY" not in readme + releasing + evidence
     assert "empty **public** `ZacharyArthur/tasterr` repository" in releasing
     assert "`check`, `e2e`, `container-smoke`, and `CodeQL`" in releasing
     assert "leave the existing `sha-<full-commit>` candidate unchanged" in releasing
-    assert "pin the `2.0.0` digest" in releasing
+    assert "pin the `2.1.0` digest" in releasing
     assert "GitHub Release is the authoritative post-tag record" in releasing
     assert "do not create a post-release evidence commit" in releasing
     assert "do not move, delete, or reuse the published tag" in releasing
@@ -141,7 +141,7 @@ def test_release_check_is_deterministic_and_keeps_external_checks_explicit() -> 
     assert "just release-check" in releasing
     assert "just audit" in releasing
     assert "just test-live" in releasing
-    assert "v2.0.0" in releasing
+    assert "v2.1.0" in releasing
     assert "archive <change-id>" in releasing
 
 
@@ -149,7 +149,7 @@ def test_public_security_policy_is_private_and_actionable() -> None:
     policy = _read(ROOT / "SECURITY.md")
     engineering = _read(DOCS / "SECURITY.md")
 
-    assert "2.0.x" in policy
+    assert "2.1.x" in policy
     assert "Security → Advisories → Report a vulnerability" in policy
     assert "Do not open a public issue" in policy
     assert "three business days" in policy
@@ -178,7 +178,7 @@ def test_plex_operator_docs_cover_privacy_recovery_and_release_order() -> None:
         "Manage Library Access",
         "downgrade to `0005`",
         "TASTERR_LIVE_PLEX_OWNER_TOKEN",
-        "Every v2.0 release candidate",
+        "Every v2.1 release candidate",
     ):
         assert term in configuration
     for term in (

--- a/backend/tests/test_release_version.py
+++ b/backend/tests/test_release_version.py
@@ -6,14 +6,14 @@ from pathlib import Path
 from pydantic import BaseModel
 
 ROOT = Path(__file__).resolve().parents[2]
-VERSION = "2.0.0"
+VERSION = "2.1.0"
 
 
 class PackageManifest(BaseModel):
     version: str
 
 
-def test_package_and_lock_metadata_are_v2() -> None:
+def test_package_and_lock_metadata_are_v2_1() -> None:
     pyproject = (ROOT / "backend" / "pyproject.toml").read_text(encoding="utf-8")
     uv_lock = (ROOT / "backend" / "uv.lock").read_text(encoding="utf-8")
     frontend = PackageManifest.model_validate_json(
@@ -41,7 +41,7 @@ def test_image_workflow_maps_v2_tag_to_release_aliases() -> None:
 
 def test_release_documents_name_the_current_stable_tag() -> None:
     releasing = (ROOT / "docs" / "RELEASING.md").read_text(encoding="utf-8")
-    evidence = (ROOT / "docs" / "releases" / "v2.0.0.md").read_text(encoding="utf-8")
+    evidence = (ROOT / "docs" / "releases" / "v2.1.0.md").read_text(encoding="utf-8")
 
     assert f"package version is\n`{VERSION}`" in releasing
     assert f"Git tag is `v{VERSION}`" in releasing

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "tasterr"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -256,7 +256,7 @@ npx @devcontainers/cli exec --workspace-folder . bash -lc 'set -a; . /tmp/taster
 
 Never put live values in `.env.example`, the repository, command output, test
 fixtures, or evidence. Record only versions and generic exercised/skipped/pass/fail
-results. Every v2.0 release candidate must pass these live contracts and the full
+results. Every v2.1 release candidate must pass these live contracts and the full
 release gate before tagging, or record the narrow release-owner exception in
 [RELEASING.md section 5](RELEASING.md#5-run-live-seerr-and-plex-contracts).
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,7 +1,7 @@
 # Releasing
 
 This procedure is for stable releases. The current package version is
-`2.0.0`, its Git tag is `v2.0.0`, and its image is published by the `image` workflow
+`2.1.0`, its Git tag is `v2.1.0`, and its image is published by the `image` workflow
 only after all release changes are squash-merged to protected `main`.
 
 ## 1. Prepare the required devcontainer
@@ -42,7 +42,7 @@ native image/Compose smoke sequentially. Any failure blocks the release.
 npx @devcontainers/cli exec --workspace-folder . just release-check
 ```
 
-Record the date and result in `docs/releases/v2.0.0.md`. This command intentionally
+Record the date and result in `docs/releases/v2.1.0.md`. This command intentionally
 does not imply that audits, security review, or live contracts passed.
 
 The committed evidence file is the pre-tag record. Write it so it remains true after
@@ -192,35 +192,35 @@ pushes.
 After every pre-tag release-record field is final, create and push the annotated tag:
 
 ```console
-npx @devcontainers/cli exec --workspace-folder . git tag -a v2.0.0 -m "v2.0.0"
-npx @devcontainers/cli exec --workspace-folder . git push origin v2.0.0
+npx @devcontainers/cli exec --workspace-folder . git tag -a v2.1.0 -m "v2.1.0"
+npx @devcontainers/cli exec --workspace-folder . git push origin v2.1.0
 ```
 
-Wait for the image workflow. It must publish `2.0.0`, `2.0`, `2`, and `latest`, and
+Wait for the image workflow. It must publish `2.1.0`, `2.1`, `2`, and `latest`, and
 leave the existing `sha-<full-commit>` candidate unchanged. Inspect the stable
 manifest and confirm both platforms:
 
 ```console
-npx @devcontainers/cli exec --workspace-folder . docker buildx imagetools inspect ghcr.io/zacharyarthur/tasterr:2.0.0
+npx @devcontainers/cli exec --workspace-folder . docker buildx imagetools inspect ghcr.io/zacharyarthur/tasterr:2.1.0
 ```
 
 Verify the stable image attestation:
 
 ```console
-gh attestation verify oci://ghcr.io/zacharyarthur/tasterr:2.0.0 -R ZacharyArthur/tasterr
+gh attestation verify oci://ghcr.io/zacharyarthur/tasterr:2.1.0 -R ZacharyArthur/tasterr
 ```
 
 Perform a fresh install in an empty directory with a new external network, disposable
 `.env`, and new Compose project. Set
-`TASTERR_IMAGE=ghcr.io/zacharyarthur/tasterr:2.0.0`, run `docker compose pull` and
+`TASTERR_IMAGE=ghcr.io/zacharyarthur/tasterr:2.1.0`, run `docker compose pull` and
 `docker compose up -d --no-build`, then verify health, SPA serving, non-root uid, and
 named-volume persistence. Delete every disposable resource after verification.
 
 Publish release notes only after the applicable manifest, attestation, and fresh
 install checks pass. Summarize user-visible changes, upgrade steps, and known
-limitations; then pin the `2.0.0` digest as the released artifact without reproducing
-private evidence. Publish v2.0.0 with repository immutability enabled only after
-`2.0.0`, `2.0`, `2`, and `latest`
+limitations; then pin the `2.1.0` digest as the released artifact without reproducing
+private evidence. Publish v2.1.0 with repository immutability enabled only after
+`2.1.0`, `2.1`, `2`, and `latest`
 resolve to the expected release commit, the `sha-<full-commit>` candidate retains its
 recorded pre-tag digest, and the tagged clean-install smoke passes.
 

--- a/docs/releases/v2.1.0.md
+++ b/docs/releases/v2.1.0.md
@@ -1,0 +1,132 @@
+# Tasterr v2.1.0 release evidence
+
+- Release date: 2026-08-30
+- Git tag: `v2.1.0`
+- Evidence status: approved for release. Deterministic checks, dependency audits,
+  security review, mandatory live contracts, and strict OpenSpec validation passed.
+  The immutable GitHub Release is the authoritative record for the final manifest
+  digest, publication time, alias verification, and tagged-image smoke result.
+
+## Scope
+
+- Selected-service rails combine recent flatrate movies and TV, alternate media
+  types while both are available, fill from the remaining side, and omit visibly
+  under-filled results. Movie and TV discovery failures degrade independently.
+- Continue Watching includes eligible next-up episodes without progress, orders them
+  by the best available item/show/season activity timestamp, preserves Plex hub order
+  when no timestamp exists, and displays episode context without a progress bar.
+  Progress-less movies remain excluded.
+- Plex approval recovery keeps polling authoritative while exposing a protected
+  approval link and repeatable copy action with accessible, flow-scoped feedback and
+  focus-safe fallback behavior.
+- The devcontainer supplies GitHub CLI and pinned OpenSpec tooling without adding a
+  host-toolchain requirement.
+- Plex playback-history requests encode their time-window comparison operators in
+  the query keys so PMS applies the intended 365-day bounds.
+- Release preparation changes only package/documentation version metadata, tests,
+  living release specifications, and this evidence. It adds no runtime behavior,
+  dependency, database, API, migration, or workflow change.
+
+## Completed verification
+
+- The merged product change passed `just check` with 643 backend tests and 111
+  frontend tests, generated API type freshness, lint and strict type checks, and the
+  production frontend build. Its real-backend Chromium E2E and native container
+  smoke also passed before release preparation.
+- Final branch `just release-check` passed on 2026-08-30 with 643 backend tests and
+  111 frontend tests, generated API type freshness, lint and strict type checks, the
+  production frontend build, one real-backend Chromium login/home/detail/request
+  journey, and native container health, private logs, hardened headers, SPA serving,
+  non-root runtime, and named-volume persistence.
+- Strict OpenSpec validation passed for `v2-1-release-readiness`, and the completed
+  change was archived with its delta synced into the living specification.
+
+## Dependency audit
+
+- `pip-audit` reported no known vulnerabilities in the frozen backend environment on
+  2026-08-29. The local `tasterr` 2.1.0 package was skipped because it is not a PyPI
+  distribution.
+- `npm audit` reported no known vulnerabilities in the frozen frontend lockfile on
+  2026-08-29.
+
+## Security review
+
+- The complete `v2.0.0..HEAD` scope was reviewed against `docs/SECURITY.md` with no
+  release-blocking finding. No API endpoint, session backend, database, migration,
+  dependency, or workflow changed. Import-boundary checks still prove that only
+  `clients/` performs outbound HTTP and only `api/` shapes browser responses.
+- Plex reads retain verified TLS, exact machine identity, disabled redirects,
+  header-only credentials, caller/account filtering, bounded work, and typed
+  upstream normalization. New timestamps are untrusted optional inputs and boolean,
+  non-positive, or non-integer values fail closed to absent.
+- The Plex recovery link uses only the backend-provided URL and opens with
+  `noopener noreferrer`; clipboard fallback is temporary, removes its element,
+  restores focus best-effort, stores no value, and has focused browser regressions.
+- GitHub verification on 2026-08-29 confirmed a public repository, private
+  vulnerability reporting, secret scanning with push protection, Dependabot alerts
+  and security updates, and that immutable GitHub Releases are enabled. Squash-only
+  merging, automatic head-branch deletion, and active protected-main and immutable
+  `v*` tag rulesets were also confirmed
+  with no bypass actors. All required workflow actions remain pinned to full SHAs;
+  package, artifact attestations, and OIDC write permissions remain confined to the
+  image publish job.
+- A fresh no-credential registry check confirmed the public `main` image is
+  anonymously readable with linux/amd64 and linux/arm64 manifests. The exact v2.1
+  candidate still requires the separate post-merge verification.
+- No generated Playwright report, trace, HAR, or log artifact is tracked. Repository
+  fixtures and release material passed placeholder/configuration regressions.
+- Release evidence contains generic outcomes only and no credential, URL, identity,
+  title, account/server identifier, viewing-data, or raw-upstream material.
+
+## Live-contract disposition
+
+- Fresh owner, PIN-protected managed, and shared-account credentials were collected
+  through Plex's approval flow and stored only in mode-0600 temporary files. An
+  initial automated run exposed incorrectly encoded playback-history comparison
+  keys; the root fix passed focused tests, the complete quality gate, and protected
+  pull-request checks before squash merge.
+- The subsequent automated Plex rerun on 2026-08-30 passed all five mandatory cases
+  against PMS `1.43.3.10896-cb3ebc72d`, covering the three account roles, verified
+  server and local-account discovery, bounded account-scoped history, Continue
+  Watching, merge timestamps, pagination, and canonical TMDB GUID mapping.
+- The same run passed all nine mandatory Seerr cases against Seerr 3.4.1, including
+  local and stored-Plex-token authentication, invalid-session behavior,
+  availability and request-history reads, attributed request creation, and verified
+  cleanup. Only the explicitly data-dependent known-available-title case skipped
+  because no library-specific identifier was supplied.
+
+## Upgrade and rollback
+
+- Before upgrading, record the running immutable digest and take and validate a
+  sensitive SQLite backup. Select `ghcr.io/zacharyarthur/tasterr:2.1.0`, pull, and
+  recreate without building. This release adds no migration.
+- Verify health, login including the Plex approval recovery link, Home including a
+  selected-service rail and Continue Watching where available, detail, and one
+  non-destructive request-state read after upgrade.
+- Rollback to v2.0 uses its prior immutable digest against the existing v2 volume.
+  To return to v1.1, keep a v2 image selected, stop the writer, downgrade migration
+  `0006` to `0005`, and then start the prior immutable v1.1 digest; alternatively
+  restore the matching validated pre-upgrade backup.
+
+## Known limitations
+
+- Plex items without a canonical TMDB GUID are omitted rather than title/year
+  guessed; legacy-agent libraries may need an agent upgrade and metadata refresh.
+- An inaccessible Plex share has no Tasterr allow/deny switch; remove its library
+  access in Plex. Usable sibling servers continue to contribute.
+- Continue Watching resolves at most twenty catalog details and uses a ten-second
+  wall-clock deadline to bound household-scale work.
+- Copy feedback is best effort when a browser rejects both clipboard mechanisms;
+  the protected approval link remains available.
+- Tasterr remains a single-process household service; multiple workers are not
+  supported.
+- One non-failing Starlette/httpx2 TestClient deprecation warning remains scheduled
+  for dependency maintenance.
+
+## Post-merge and post-tag record
+
+After the release-readiness PR merges, the exact SHA candidate must pass manifest,
+attestation, public visibility, anonymous pull, and disposable clean-install checks
+before tagging. After `v2.1.0`, stable aliases, final digest, attestation, and fresh
+tagged-install results are recorded only in the immutable GitHub Release. No
+post-release source commit is created solely to record those later facts.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "frontend",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "2.0.0",
+			"version": "2.1.0",
 			"dependencies": {
 				"@tailwindcss/vite": "^4.3.2",
 				"@tanstack/react-query": "^5.101.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/openspec/changes/archive/2026-08-30-v2-1-release-readiness/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-30-v2-1-release-readiness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/archive/2026-08-30-v2-1-release-readiness/design.md
+++ b/openspec/changes/archive/2026-08-30-v2-1-release-readiness/design.md
@@ -1,0 +1,113 @@
+## Context
+
+The reviewed tooling, Plex recovery, and discovery-rail changes are merged on
+`main`. The protected-branch, immutable-tag, GHCR, attestation, and release-check
+machinery already supports a minor release. See `proposal.md` for motivation and
+`specs/release-readiness/spec.md` for the updated contract.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `2.1.0` the single current version across manifests, lockfiles, regressions,
+  current operator docs, support policy, and release evidence.
+- Produce a redacted, reviewable pre-tag record for changes since `v2.0.0`.
+- Reuse the existing candidate-first release pipeline and immutable publication
+  order.
+
+**Non-Goals:**
+
+- Runtime, API, dependency, database, migration, or workflow changes.
+- Rewriting historical v2.0 evidence or its `0006` migration boundary.
+- Recording secrets, private coordinates, household data, or raw logs.
+
+## Decisions
+
+### 1. Reuse the existing release pipeline unchanged
+
+Only version-bearing metadata, assertions, current docs/specs, and a new evidence
+file change. Existing SemVer, main-ancestry, multi-architecture, attestation, and
+stable-alias rules already cover `v2.1.0`.
+
+Alternative: add minor-release workflow logic. Rejected because generic SemVer rules
+already produce the required aliases.
+
+### 2. Change only current-version references
+
+Package roots, current deployment examples, support policy, regressions, the living
+release spec, and release runbook move to `2.1.0`. The published v2.0 evidence and
+historical statements about migration `0006` remain unchanged.
+
+Alternative: mechanically replace every `2.0.0` occurrence. Rejected because that
+would corrupt dependency data and release history.
+
+### 3. Keep pre-tag and post-tag evidence separate
+
+The committed record contains branch-verifiable gates and an approved disposition.
+The exact merged SHA candidate, final digest, stable aliases, attestations, and
+tagged-image smoke belong in the immutable GitHub Release after they exist.
+
+Alternative: commit post-merge facts. Rejected because that creates a new candidate
+and invalidates the facts being recorded.
+
+### 4. Preserve migration-aware rollback
+
+The v2.1 delta adds no migration, so rollback to v2.0 uses its immutable digest.
+Rollback to v1.1 still requires the existing `0006` to `0005` downgrade with a v2
+image or restoration of the matching validated pre-upgrade backup.
+
+Alternative: describe all rollback as image-only. Rejected because that is unsafe
+across the v2 schema boundary.
+
+### 5. Apply the existing live-contract exception narrowly
+
+A fresh `just test-live` run remains the default. The release-owner baseline plus
+fresh integrated-manual-test exception is available only if credentials cannot
+complete the run and this release-prep delta remains behavior-free. Evidence must
+distinguish the exception from an automated pass.
+
+Alternative: treat retained baselines as a fresh pass. Rejected because that would
+misstate measured evidence.
+
+## Security considerations
+
+- No API, auth/session, outbound HTTP, frontend rendering, or database code changes
+  in release preparation; the merged runtime scope is reviewed against the full
+  applicable `docs/SECURITY.md` checklists.
+- Both frozen dependency sets are audited; any advisory is fixed or documented with
+  its identifier, affected surface, and explicit disposition before tagging.
+- Placeholder fixtures, staged files, logs, and evidence are checked for secrets,
+  private URLs, identities, viewing data, and generated failure artifacts.
+- GitHub vulnerability reporting, secret scanning/push protection, dependency
+  alerts/updates, protected `main`, immutable releases, and immutable `v*` tags are
+  verified before publication.
+- Candidate and stable images must be public, anonymously pullable,
+  multi-architecture, repository-linked, and covered by valid artifact attestations.
+- No dependency is added.
+
+## Risks / Trade-offs
+
+- **Live credentials may be stale** → Prefer a fresh rerun; otherwise require the
+  documented complete baseline, fresh owner manual test, release-only delta, and
+  explicit exception.
+- **Post-merge images may differ from branch-local builds** → Verify the exact SHA
+  candidate before tagging, then verify stable aliases after tagging.
+- **Publication may fail after the immutable tag exists** → Never move or reuse the
+  tag; fix forward through protected `main`.
+- **Rollback guidance may obscure the old schema boundary** → State both the simple
+  v2.1-to-v2.0 path and the required v2-to-v1.1 downgrade path.
+
+## Migration Plan
+
+1. Update version metadata, current docs/specs, regressions, and redacted evidence.
+2. Run audits, deterministic release checks, live-contract disposition, full-tree
+   security/repository review, strict OpenSpec validation, and archive this change.
+3. Commit, push, review, and squash-merge through the required protected-branch
+   gates.
+4. On merged `main`, rerun the release gate and verify the exact SHA candidate.
+5. Create and push `v2.1.0`; verify `2.1.0`, `2.1`, `2`, `latest`, attestation, and a
+   fresh tagged deployment.
+6. Publish the immutable GitHub Release with the post-tag facts.
+
+Rollback before tagging is an ordinary correction through the release PR. After
+tagging, preserve the tag and fix forward. Runtime rollback follows decision 4.

--- a/openspec/changes/archive/2026-08-30-v2-1-release-readiness/proposal.md
+++ b/openspec/changes/archive/2026-08-30-v2-1-release-readiness/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+The tooling, Plex recovery, and discovery-rail improvements are merged on `main`,
+but package metadata and current release material still identify `2.0.0`. The
+repository needs its audited release-readiness step before `v2.1.0` can be tagged
+and announced.
+
+## What Changes
+
+- Set backend, frontend, lockfile, and release-regression metadata to `2.1.0`.
+- Advance the copyable README deployment example and supported-version policy to
+  the v2.1 stable line without rewriting historical v2.0 migration facts.
+- Update current release/configuration guidance for the v2.1 candidate, stable
+  aliases, attestation, clean-install, upgrade, and rollback sequence.
+- Add a redacted `v2.1.0` pre-tag evidence record covering the merged scope since
+  v2.0.0, deterministic checks, dependency audits, security review, live-contract
+  disposition, known limitations, and rollback basis.
+- After gated merge, verify the multi-architecture SHA candidate, public anonymous
+  install, and attestation before creating `v2.1.0`; then verify stable aliases and
+  publish an immutable GitHub Release.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `release-readiness`: Advance package, documentation, evidence, and publication
+  requirements from the v2.0 stable line to the audited v2.1 release.
+
+## Non-goals
+
+- Changing runtime behavior, API contracts, dependencies, or database schema.
+- Weakening deterministic checks, dependency audits, live contracts, repository
+  security controls, provenance verification, or clean-install smoke.
+- Recording private URLs, credentials, household identities, title/viewing data,
+  raw logs, or unredacted live evidence.
+- Rewriting the historical v2.0 evidence, migration boundary, or published tags.
+- Moving, deleting, or reusing a published tag if post-tag verification fails.
+
+## Impact
+
+- Metadata: backend/frontend manifests, both lockfiles, and version regressions.
+- Documentation: README, public support policy, configuration/releasing guides,
+  living release-readiness spec, and `docs/releases/v2.1.0.md` evidence.
+- Delivery: protected PR gates, GHCR candidate/stable tags and attestations, the
+  immutable `v2.1.0` Git tag, and GitHub Release.
+- Milestone: advances the existing release-readiness capability for the merged
+  post-v2.0 tooling, Plex recovery, and richer discovery-rail changes.

--- a/openspec/changes/archive/2026-08-30-v2-1-release-readiness/specs/release-readiness/spec.md
+++ b/openspec/changes/archive/2026-08-30-v2-1-release-readiness/specs/release-readiness/spec.md
@@ -1,10 +1,4 @@
-# release-readiness Specification
-
-## Purpose
-Define the documentation, security, verification, evidence, and publication controls
-that make a stable Tasterr release repeatable and safe to operate.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Release-facing documentation is complete and linked
 

--- a/openspec/changes/archive/2026-08-30-v2-1-release-readiness/tasks.md
+++ b/openspec/changes/archive/2026-08-30-v2-1-release-readiness/tasks.md
@@ -1,0 +1,30 @@
+## 1. Version and Release Documentation
+
+- [x] 1.1 Set backend/frontend package and lock metadata to `2.1.0`, update the
+  release-version regressions, and verify unrelated dependency versions are
+  unchanged.
+- [x] 1.2 Advance the README, support policy, current configuration/releasing text,
+  and documentation regressions to v2.1 while preserving historical v2.0 evidence
+  and migration facts; verify the focused documentation/version tests pass.
+- [x] 1.3 Add `docs/releases/v2.1.0.md` with redacted scope, upgrade/rollback,
+  limitations, and only branch-verifiable outcomes; verify the evidence regression
+  passes without predicting post-merge/tag facts.
+
+## 2. Pre-Tag Verification and Evidence
+
+- [x] 2.1 Review the complete `v2.0.0..HEAD` scope and repository contents against
+  `docs/SECURITY.md`; record generic results and verify no secret, private, or
+  generated failure material is staged.
+- [x] 2.2 Run `just release-check` and `just audit` inside the devcontainer, resolve
+  actionable failures or record advisory-specific dispositions, and update the
+  v2.1 evidence with exact generic outcomes.
+- [x] 2.3 Run mandatory live Seerr and owner/managed/shared Plex contracts when
+  current credentials permit; otherwise record only a qualifying release-owner
+  baseline/manual-test exception and never claim a fresh automated pass.
+- [x] 2.4 Verify GitHub repository security controls and the candidate/tag runbook,
+  record the generic result, and confirm post-merge facts require no source commit.
+- [x] 2.5 Run strict OpenSpec validation and fix every release artifact issue.
+
+## 3. Final Quality Gate
+
+- [x] 3.1 Run `just check` inside the devcontainer and fix any failures.


### PR DESCRIPTION
## What / why

Prepare v2.1.0 for publication after the merged service-rail, Continue Watching, Plex approval recovery, devcontainer tooling, and Plex history-bound fixes.

Update backend and frontend version metadata, current operator documentation, and release regressions. Add redacted v2.1.0 evidence, advance the living release-readiness specification, and archive the completed change.

## Spec

- OpenSpec change: `v2-1-release-readiness` (archived as `2026-08-30-v2-1-release-readiness`)

## Checklist

- [x] `just release-check` passes locally
- [x] `just audit` reports no known vulnerabilities
- [x] Mandatory Plex and Seerr live contracts pass
- [x] Strict OpenSpec validation passes
- [x] Title is the Conventional Commit subject for the squash
